### PR TITLE
Dev/grade management　ER図のリレーション方向修正・カラム設計整理・gradesエンティティ追加

### DIFF
--- a/grade-management/doc/er_design.mmd
+++ b/grade-management/doc/er_design.mmd
@@ -1,7 +1,14 @@
 erDiagram
     teachers ||--o{ main_subjects : "specialized"
-    classes }o--|| teachers : "class_id"
-    classes }o--|| students : "class_id" 
+    classes ||--o{ students : "class_id"
+    classes ||--o| teachers : "class_id"
+    grades }o--|| students: "students_id"
+    exams ||--o{ grades : "exam_id"
+
+%% ||--o{ : 「1対多」
+%% || (左側) : 1側。片側が必ず1つであることを示します（必須）。
+%% o{ (右側) : 多側。0個以上（Zero or Many）であることを示します。
+%% ||--|{ : 1対多かつ、「多側」が1つ以上（One or Many）。 
 
     teachers {
         int id PK "担任・専科"
@@ -18,8 +25,7 @@ erDiagram
     }
 
     students {
-        int id PK "在籍番号"
-    %% TODO プロトタイプ仕様書にある、year,class,numberが抜けている
+        int id PK "学生番号"
         string name "氏名"
         int class_id FK "在籍クラス"
     }
@@ -29,9 +35,17 @@ erDiagram
         string name "(国語, 数学...)"
     }
 
+
     exams {
         int id PK
         string quarter "中間・期末"
         string period "前期・後期"
     }
 
+    grades {
+        int id PK
+        int students_id FK 
+        int exam_id FK "前期中間、後期期末、、、"
+        int main_subjects_id FK
+        int score 
+    }


### PR DESCRIPTION
## 概要
成績管理システムのER図（er_design.mmd）について、リレーション方向の誤りを修正し、カラム設計を整理した。

## 変更内容
- teachers, students に class_id FK を持たせ、classes との関係方向を修正
- classes テーブルから teachers_id / students_id FK を削除し、クラス側が個別に生徒・先生を持つ設計を解消
- teachers の重複していた specialized カラムを整理
- grades エンティティを新規追加（students_id, exam_id, main_subjects_id, score）
- students の PK コメントを「在籍番号」→「学生番号」に変更
- 旧 TODO コメントを削除
