### PR TITLE
feat(#15): CSV ダウンロード機能を追加

### DIFF
--- a/grade-management/web/src/classes/CsvExporter.php
+++ b/grade-management/web/src/classes/CsvExporter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App;
+
+class CsvExporter
+{
+    private const HEADERS = ['学生番号', 'クラス', '出席番号', '氏名', '国語', '数学', '英語', '理科', '社会', '合計'];
+
+    public static function generate(array $exams): string
+    {
+        $output = fopen('php://temp', 'r+');
+
+        // BOM なし UTF-8 ヘッダー行
+        fputcsv($output, self::HEADERS);
+
+        foreach ($exams as $exam) {
+            fputcsv($output, [
+                $exam['student_id'],
+                $exam['grade'] . $exam['class_name'],
+                $exam['student_number'],
+                $exam['student_name'],
+                $exam['kokugo']  ?? '',
+                $exam['sugaku']  ?? '',
+                $exam['eigo']    ?? '',
+                $exam['rika']    ?? '',
+                $exam['shakai']  ?? '',
+                $exam['goukei']  ?? '',
+            ]);
+        }
+
+        rewind($output);
+        $csv = stream_get_contents($output);
+        fclose($output);
+
+        return $csv;
+    }
+}

--- a/grade-management/web/src/exams/download.php
+++ b/grade-management/web/src/exams/download.php
@@ -1,4 +1,59 @@
 <?php
-// TODO: #15 CSV ダウンロード
-header('Location: /exams/index.php');
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use App\CsvExporter;
+use App\Database;
+
+$db = Database::getConnection();
+
+$testId  = isset($_GET['test_id']) ? (int) $_GET['test_id'] : 0;
+$sortMap = [
+    'student_id' => 'e.student_id ASC',
+    'class'      => 'c.grade ASC, c.class_name ASC, s.number ASC',
+    'number'     => 's.number ASC',
+    'name'       => 's.name ASC',
+    'kokugo'     => 'e.kokugo DESC',
+    'sugaku'     => 'e.sugaku DESC',
+    'eigo'       => 'e.eigo DESC',
+    'rika'       => 'e.rika DESC',
+    'shakai'     => 'e.shakai DESC',
+    'goukei'     => 'e.goukei DESC',
+];
+$sortKey = $_GET['sort'] ?? 'class';
+if (!array_key_exists($sortKey, $sortMap)) {
+    $sortKey = 'class';
+}
+
+if ($testId <= 0) {
+    header('Location: /exams/index.php');
+    exit;
+}
+
+$stmt = $db->prepare(
+    'SELECT e.*, s.name AS student_name, s.number AS student_number, c.grade, c.class_name
+     FROM exams e
+     JOIN students s ON s.id = e.student_id
+     JOIN classes c ON c.id = s.class_id
+     WHERE e.test_id = :test_id
+     ORDER BY ' . $sortMap[$sortKey]
+);
+$stmt->execute([':test_id' => $testId]);
+$exams = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$stmt2 = $db->prepare('SELECT year, name FROM tests WHERE id = :id');
+$stmt2->execute([':id' => $testId]);
+$test = $stmt2->fetch(PDO::FETCH_ASSOC);
+
+$filename = $test
+    ? $test['year'] . '年度_' . $test['name'] . '.csv'
+    : 'exams.csv';
+
+$csv = CsvExporter::generate($exams);
+
+// UTF-8 BOM 付きで出力（Excel での文字化け防止）
+header('Content-Type: text/csv; charset=UTF-8');
+header('Content-Disposition: attachment; filename="' . rawurlencode($filename) . '"');
+header('Cache-Control: no-cache');
+
+echo "\xEF\xBB\xBF" . $csv;
 exit;

--- a/grade-management/web/src/exams/index.php
+++ b/grade-management/web/src/exams/index.php
@@ -88,6 +88,8 @@ function sortLink(string $key, string $label, string $currentSort, int $testId):
 
     <a href="/exams/create.php?test_id=<?= $selectedTestId ?>">＋ このテストの成績を一括登録</a>
 
+    <a href="/exams/download.php?test_id=<?= $selectedTestId ?>&sort=<?= htmlspecialchars($sortKey) ?>">↓ CSVダウンロード</a>
+
     <table border="1" cellpadding="6" style="margin-top:1em;border-collapse:collapse;">
       <thead>
         <tr>

--- a/grade-management/web/src/tests_unit/CsvExporterTest.php
+++ b/grade-management/web/src/tests_unit/CsvExporterTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests;
+
+use App\CsvExporter;
+use PHPUnit\Framework\TestCase;
+
+class CsvExporterTest extends TestCase
+{
+    public function testヘッダー行が含まれる(): void
+    {
+        $csv = CsvExporter::generate([]);
+        $lines = explode("\n", trim($csv));
+
+        $this->assertSame(
+            '学生番号,クラス,出席番号,氏名,国語,数学,英語,理科,社会,合計',
+            $lines[0]
+        );
+    }
+
+    public function testデータ行が正しく出力される(): void
+    {
+        $exams = [
+            [
+                'student_id'     => 1,
+                'grade'          => '1年',
+                'class_name'     => 'A組',
+                'student_number' => 1,
+                'student_name'   => '山田 太郎',
+                'kokugo'         => 85,
+                'sugaku'         => 90,
+                'eigo'           => 78,
+                'rika'           => 88,
+                'shakai'         => 92,
+                'goukei'         => 433,
+            ],
+        ];
+
+        $csv = CsvExporter::generate($exams);
+        $lines = explode("\n", trim($csv));
+
+        $this->assertSame('1,1年A組,1,"山田 太郎",85,90,78,88,92,433', $lines[1]);
+    }
+
+    public function test未入力の点数は空文字で出力される(): void
+    {
+        $exams = [
+            [
+                'student_id'     => 2,
+                'grade'          => '1年',
+                'class_name'     => 'B組',
+                'student_number' => 1,
+                'student_name'   => '鈴木 花子',
+                'kokugo'         => null,
+                'sugaku'         => null,
+                'eigo'           => null,
+                'rika'           => null,
+                'shakai'         => null,
+                'goukei'         => null,
+            ],
+        ];
+
+        $csv = CsvExporter::generate($exams);
+        $lines = explode("\n", trim($csv));
+
+        $this->assertSame('2,1年B組,1,"鈴木 花子",,,,,,' , $lines[1]);
+    }
+
+    public function test複数行出力できる(): void
+    {
+        $exams = [
+            [
+                'student_id' => 1, 'grade' => '1年', 'class_name' => 'A組',
+                'student_number' => 1, 'student_name' => '山田 太郎',
+                'kokugo' => 85, 'sugaku' => 90, 'eigo' => 78,
+                'rika' => 88, 'shakai' => 92, 'goukei' => 433,
+            ],
+            [
+                'student_id' => 2, 'grade' => '1年', 'class_name' => 'A組',
+                'student_number' => 2, 'student_name' => '鈴木 花子',
+                'kokugo' => 72, 'sugaku' => 65, 'eigo' => 80,
+                'rika' => 70, 'shakai' => 75, 'goukei' => 362,
+            ],
+        ];
+
+        $csv = CsvExporter::generate($exams);
+        $lines = explode("\n", trim($csv));
+
+        $this->assertCount(3, $lines); // ヘッダー + 2行
+    }
+
+    public function testカンマを含む氏名はダブルクォートで囲まれる(): void
+    {
+        $exams = [
+            [
+                'student_id' => 1, 'grade' => '1年', 'class_name' => 'A組',
+                'student_number' => 1, 'student_name' => '山田,太郎',
+                'kokugo' => 85, 'sugaku' => 90, 'eigo' => 78,
+                'rika' => 88, 'shakai' => 92, 'goukei' => 433,
+            ],
+        ];
+
+        $csv = CsvExporter::generate($exams);
+        $lines = explode("\n", trim($csv));
+
+        $this->assertStringContainsString('"山田,太郎"', $lines[1]);
+    }
+}


### PR DESCRIPTION
## Summary
- `CsvExporter` クラスで CSV 生成ロジックを分離し TDD で実装（PHPUnit 5テスト）
- `exams/download.php` で現在のソート順を維持したまま CSV 出力
- Excel 文字化け防止のため UTF-8 BOM 付きで出力、ファイル名は `年度_テスト名.csv`

## Test plan
- [x] `make test` で 24 tests 全グリーンを確認
- [x] 成績一覧で「↓ CSVダウンロード」リンクをクリックしてファイルがダウンロードされること
- [x] Excel で開いて文字化けしないこと
- [x] ソート順（クラス順・合計点順など）が CSV に反映されること
- [x] 点数未入力行が空セルになっていること

Closes #15