### PR TITLE
chore: テスト環境の整備 (#42)

### DIFF
--- a/hotel-reservation/src/phpunit.xml
+++ b/hotel-reservation/src/phpunit.xml
@@ -25,6 +25,9 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_DATABASE" value="testing"/>
         <env name="DB_URL" value=""/>
+        <env name="DB_HOST" value="mysql"/>
+        <env name="DB_USERNAME" value="sail"/>
+        <env name="DB_PASSWORD" value="password"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
## 概要

DBを使うテストが書ける状態にする。

## 変更内容

- `phpunit.xml` に `DB_HOST` / `DB_USERNAME` / `DB_PASSWORD` を追加
- Sail がMySQLコンテナ起動時に `testing` DBを自動作成する仕組みを活用
- SQLite in-memory ではなく MySQL testing DB を使用する方針

## 確認

- `sail artisan test` で 2件パス済み

Closes #42