### PR TITLE
chore: xdebugとLaravel Debugbarの開発環境を整備（Issue #46）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```
 your-school/
 ├── hotel-reservation/
+│   ├── .vscode/launch.json   # VSCode xdebug設定（hotel-reservationをワークスペースルートとして開くこと）
 │   ├── doc/                  # 設計ドキュメント（ER図・画面遷移図・テーブル定義書）
 │   ├── specification.md      # 仕様書
 │   └── src/                  # Laravelアプリ本体
@@ -28,6 +29,8 @@ your-school/
 - **PHP CS Fixer** PSR-12（フォーマット）
 - **CaptainHook**（pre-commit フック）
 - **PHPUnit 12**（テスト）
+- **Xdebug 3**（ステップデバッグ）
+- **Laravel Debugbar**（ブラウザ内デバッグツールバー）
 
 ## 開発環境の特殊事情
 
@@ -82,7 +85,16 @@ main                        # 課題完成後にのみマージ
 - Larastan level 6 をパスすること
 - コミット前に pre-commit フックが自動で両方を実行する
 
+## Xdebug 使い方
+
+1. VSCode のデバッグパネルで「Listen for Xdebug (Sail)」を選択して F5
+2. ブラウザの Xdebug Helper 拡張を **Debug** モードに切り替える
+3. `http://localhost:8888` にアクセス → ブレークポイントで停止
+
+- `start_with_request=default` のため、Xdebug Helper なしの場合は `?XDEBUG_SESSION=1` クエリパラメータが必要
+- `.env` の `SAIL_XDEBUG_MODE=develop,debug` で有効化済み
+
 ## 現在の作業状況
 
-- **完了**: 環境構築、Larastan、PHP CS Fixer、CaptainHook、GitHub Actions CI
+- **完了**: 環境構築、Larastan、PHP CS Fixer、CaptainHook、GitHub Actions CI、Xdebug、Laravel Debugbar
 - **検討中**: Issue #42 — テスト環境の整備（SQLite in-memory vs MySQL testing DB、ユーザーが方針を決定中）

--- a/hotel-reservation/.vscode/launch.json
+++ b/hotel-reservation/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug (Sail)",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html": "${workspaceFolder}/src"
+            },
+            "ignore": ["**/vendor/**/*.php"]
+        }
+    ]
+}

--- a/hotel-reservation/src/.env.example
+++ b/hotel-reservation/src/.env.example
@@ -63,3 +63,6 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+SAIL_XDEBUG_MODE=off
+SAIL_XDEBUG_CONFIG="client_host=host.docker.internal"

--- a/hotel-reservation/src/.gitignore
+++ b/hotel-reservation/src/.gitignore
@@ -18,6 +18,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/debugbar
 /storage/pail
 /vendor
 .php-cs-fixer.cache

--- a/hotel-reservation/src/composer.json
+++ b/hotel-reservation/src/composer.json
@@ -14,6 +14,7 @@
         "laravel/tinker": "^3.0"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^4.2",
         "captainhook/captainhook": "^5.29",
         "fakerphp/faker": "^1.23",
         "friendsofphp/php-cs-fixer": "^3.95",

--- a/hotel-reservation/src/composer.lock
+++ b/hotel-reservation/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ec4190bdc283d424f28e45555c7be10",
+    "content-hash": "dc5ff8554a5e85b66fb18a44e1cea3ab",
     "packages": [
         {
             "name": "brick/math",
@@ -5889,6 +5889,105 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/laravel-debugbar.git",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^11|^12|^13.0",
+                "illuminate/session": "^11|^12|^13.0",
+                "illuminate/support": "^11|^12|^13.0",
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.7.2",
+                "php-debugbar/symfony-bridge": "^1.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3",
+                "laravel/octane": "^2",
+                "laravel/pennant": "^1",
+                "laravel/pint": "^1",
+                "laravel/telescope": "^5.16",
+                "livewire/livewire": "^3.7|^4",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^9|^10|^11",
+                "php-debugbar/twig-bridge": "^2.0",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11",
+                "shipmonk/phpstan-rules": "^4.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Debugbar": "Fruitcake\\LaravelDebugbar\\Facades\\Debugbar"
+                    },
+                    "providers": [
+                        "Fruitcake\\LaravelDebugbar\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Fruitcake\\LaravelDebugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "barryvdh",
+                "debug",
+                "debugbar",
+                "dev",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/laravel-debugbar/issues",
+                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-20T13:31:29+00:00"
+        },
+        {
             "name": "captainhook/captainhook",
             "version": "5.29.2",
             "source": {
@@ -7479,6 +7578,174 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-debugbar/php-debugbar",
+            "version": "v3.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/php-debugbar.git",
+                "reference": "dbf77f48fa6e6b57ed57ae67aa047b2535697788"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/dbf77f48fa6e6b57ed57ae67aa047b2535697788",
+                "reference": "dbf77f48fa6e6b57ed57ae67aa047b2535697788",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6|^7|^8"
+            },
+            "replace": {
+                "maximebf/debugbar": "self.version"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "friendsofphp/php-cs-fixer": "^3.92",
+                "monolog/monolog": "^3.9",
+                "php-debugbar/doctrine-bridge": "^3@dev",
+                "php-debugbar/monolog-bridge": "^1@dev",
+                "php-debugbar/symfony-bridge": "^1@dev",
+                "php-debugbar/twig-bridge": "^2@dev",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10",
+                "predis/predis": "^3.3",
+                "shipmonk/phpstan-rules": "^4.3",
+                "symfony/browser-kit": "^6.4|7.0",
+                "symfony/dom-crawler": "^6.4|^7",
+                "symfony/event-dispatcher": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1",
+                "twig/twig": "^3.11.2"
+            },
+            "suggest": {
+                "php-debugbar/doctrine-bridge": "To integrate Doctrine with php-debugbar.",
+                "php-debugbar/monolog-bridge": "To integrate Monolog with php-debugbar.",
+                "php-debugbar/symfony-bridge": "To integrate Symfony with php-debugbar.",
+                "php-debugbar/twig-bridge": "To integrate Twig with php-debugbar."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debug",
+                "debug bar",
+                "debugbar",
+                "dev",
+                "profiler",
+                "toolbar"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v3.7.5"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-15T11:58:43+00:00"
+        },
+        {
+            "name": "php-debugbar/symfony-bridge",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/symfony-bridge.git",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/symfony-bridge/zipball/e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "phpunit/phpunit": "^10",
+                "symfony/browser-kit": "^6|^7",
+                "symfony/dom-crawler": "^6|^7",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\Bridge\\Symfony\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Symfony bridge for PHP Debugbar",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debugbar",
+                "dev",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/symfony-bridge/issues",
+                "source": "https://github.com/php-debugbar/symfony-bridge/tree/v1.1.0"
+            },
+            "time": "2026-01-15T14:47:34+00:00"
         },
         {
             "name": "phpstan/phpstan",


### PR DESCRIPTION
## 概要

VSCode + Laravel Sail でのデバッグ環境を整備した。

## 変更内容

- **`.vscode/launch.json` を追加**（`hotel-reservation/` 直下）
  - VSCode のデバッグパネルから「Listen for Xdebug (Sail)」で起動可能
  - `pathMappings: /var/www/html → ${workspaceFolder}/src`
- **`src/.env.example` に xdebug 設定を追加**
  - `SAIL_XDEBUG_MODE=off`（デフォルト off、開発時は `develop,debug` に変更）
  - `SAIL_XDEBUG_CONFIG="client_host=host.docker.internal"`
- **Laravel Debugbar を導入**（`barryvdh/laravel-debugbar` ^4.2、dev依存）
  - `APP_DEBUG=true` 環境でブラウザ下部にツールバーが表示される
- **`src/.gitignore` に `/storage/debugbar` を追加**
- **`CLAUDE.md` を更新**（xdebug使い方・技術スタック・作業状況）

## Xdebug 使い方

1. F5 で「Listen for Xdebug (Sail)」を起動
2. ブラウザの Xdebug Helper 拡張を Debug モードに切り替え
3. `http://localhost:8888` にアクセス → ブレークポイントで停止

## テスト計画

- [ ] F5 でデバッグセッションが開始される（ステータスバーがオレンジ）
- [ ] ブレークポイントでリクエストが停止する
- [ ] `http://localhost:8888` でブラウザ下部に Debugbar が表示される