### PR TITLE
fix: レビュー指摘のER図・テーブル定義書を修正（Issue #48）

### DIFF
--- a/hotel-reservation/doc/er.mmd
+++ b/hotel-reservation/doc/er.mmd
@@ -35,7 +35,7 @@ erDiagram
         string address
         string phone
         string message
-        string status
+        tinyint status
         string memo
         datetime created_at
         datetime updated_at
@@ -45,7 +45,7 @@ erDiagram
     reservation_slots {
         int id
         int room_type_id
-        int status
+        tinyint status
         datetime start
         datetime end
         datetime created_at
@@ -98,7 +98,7 @@ erDiagram
         string address
         string phone
         string message
-        string status
+        tinyint status
         datetime created_at
         datetime updated_at
     }

--- a/hotel-reservation/doc/table_define.md
+++ b/hotel-reservation/doc/table_define.md
@@ -27,7 +27,7 @@
 | first_name | VARCHAR(255) | NO | - ||  
 | email | VARCHAR(255) | NO | - ||  
 | address | VARCHAR(255) | NO | - ||  
-| phone | VARCHAR(255) | NO | - ||  
+| phone | VARCHAR(20) | NO | - ||  
 | message | TEXT | YES | NULL ||  
 | status | TINYINT | NO | 1 | 1:予約済 2:キャンセル |
 | memo | TEXT | YES | NULL ||  
@@ -94,7 +94,7 @@
 | first_name | VARCHAR(255) | NO | - ||  
 | email | VARCHAR(255) | NO | - ||  
 | address | VARCHAR(255) | NO | - ||  
-| phone | VARCHAR(255) | NO | - ||  
+| phone | VARCHAR(20) | NO | - ||  
 | message | TEXT | YES | NULL ||  
 | status | TINYINT | NO | 1 | 1:問い合わせ中 2:完了 |
 | created_at | DATETIME | NO | - ||  
@@ -106,7 +106,7 @@
 | id | BIGINT UNSIGNED | NO | AUTO_INCREMENT | PK |
 | last_name | VARCHAR(255) | NO | - ||  
 | first_name | VARCHAR(255) | NO | - ||  
-| email | VARCHAR(255) | NO | - ||  
+| email | VARCHAR(255) | NO | - | UNIQUE |  
 | password | VARCHAR(255) | NO | - ||  
 | created_at | DATETIME | NO | - ||  
 | updated_at | DATETIME | YES | NULL ||    


### PR DESCRIPTION
## 概要

レビューで指摘された設計ドキュメントの不備を修正。

## 変更内容

### 1. ER図のstatus型をtinyintに統一
- `reservations.status`：`string` → `tinyint`
- `reservation_slots.status`：`int` → `tinyint`
- `inquiries.status`：`string` → `tinyint`（同様の不一致のため合わせて修正）

### 2. admins.email にUNIQUE制約を追記
- 備考欄に `UNIQUE` を追記

### 3. phone のVARCHAR長を修正
- `reservations.phone`：VARCHAR(255) → VARCHAR(20)
- `inquiries.phone`：VARCHAR(255) → VARCHAR(20)

## 関連Issue
Closes #48