### PR TITLE
feat: 全テーブルのマイグレーションを作成（Issue #52）

### DIFF
--- a/hotel-reservation/src/database/migrations/2026_04_25_021356_create_admins_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021356_create_admins_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('last_name');
+            $table->string('first_name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021359_create_room_types_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021359_create_room_types_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('room_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->unsignedInteger('count');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('room_types');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021403_create_accommodation_plans_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021403_create_accommodation_plans_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('accommodation_plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('accommodation_plans');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021406_create_plan_images_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021406_create_plan_images_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plan_images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('accommodation_plan_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('image_path');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plan_images');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021409_create_plan_room_prices_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021409_create_plan_room_prices_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plan_room_prices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('room_type_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('accommodation_plan_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('price');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+
+            $table->unique(['room_type_id', 'accommodation_plan_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plan_room_prices');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021412_create_reservation_slots_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021412_create_reservation_slots_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reservation_slots', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('room_type_id')->constrained()->cascadeOnDelete();
+            $table->tinyInteger('status')->default(1);
+            $table->date('start');
+            $table->date('end');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+
+            $table->index(['start', 'end']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_slots');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021415_create_reservations_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021415_create_reservations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reservations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_slot_id')->constrained()->restrictOnDelete();
+            $table->foreignId('accommodation_plan_id')->constrained()->restrictOnDelete();
+            $table->string('plan_name');
+            $table->unsignedInteger('price');
+            $table->string('last_name');
+            $table->string('first_name');
+            $table->string('email');
+            $table->string('address');
+            $table->string('phone', 20);
+            $table->text('message')->nullable();
+            $table->tinyInteger('status')->default(1);
+            $table->text('memo')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservations');
+    }
+};

--- a/hotel-reservation/src/database/migrations/2026_04_25_021417_create_inquiries_table.php
+++ b/hotel-reservation/src/database/migrations/2026_04_25_021417_create_inquiries_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('inquiries', function (Blueprint $table) {
+            $table->id();
+            $table->string('last_name');
+            $table->string('first_name');
+            $table->string('email');
+            $table->string('address');
+            $table->string('phone', 20);
+            $table->text('message')->nullable();
+            $table->tinyInteger('status')->default(1);
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inquiries');
+    }
+};


### PR DESCRIPTION
## 概要

テーブル定義書をもとに全8テーブルのマイグレーションを作成。

Closes #52

## 作成テーブル

- `admins`（管理者）
- `room_types`（部屋タイプ）
- `accommodation_plans`（宿泊プラン）
- `plan_images`（宿泊プランイメージ）
- `plan_room_prices`（プラン×部屋タイプの料金）
- `reservation_slots`（予約枠）
- `reservations`（予約）
- `inquiries`（問い合わせ）

## 設計上の判断

### plan_room_prices: 複合ユニーク制約を追加
`unique(['room_type_id', 'accommodation_plan_id'])` を追加。
`foreignId` で単体インデックスは自動生成されるが、1プラン×1部屋タイプ=1レコードの一意性は明示しないと保証されないため。

### reservation_slots: インデックスを `['start', 'end']` に変更
MySQLの複合インデックスは最初の範囲条件でストップするため、`start` が範囲条件になった時点で `end` は使われない。`status` を先頭に置く意味が薄いためシンプルに `['start', 'end']` に変更。

### accommodation_plans / room_types: SoftDeletes を追加
`restrictOnDelete` のみでは「削除できないし非表示にもできない」状態になる。
`reservations` にはプラン名・料金のスナップショットがあるため、論理削除（SoftDeletes）で「隠す」設計とした。

### reservations の FK: `cascadeOnDelete` → `restrictOnDelete` に変更
予約データは履歴として保持すべきであり、親レコード（予約枠・宿泊プラン）の削除に連鎖して消えてはならない。予約が存在する間は親を削除できないよう DB レベルで保護する。

## テスト

`sail artisan migrate` で全件適用済み。エラーなし。