### PR TITLE
feat: 管理者認証を実装（Issue #54）

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class LoginController extends Controller
+{
+    public function show(): View
+    {
+        return view('admin.auth.login');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (!Auth::guard('admin')->attempt($credentials, $request->boolean('remember'))) {
+            return back()->withErrors([
+                'email' => 'メールアドレスまたはパスワードが正しくありません。',
+            ]);
+        }
+
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('admin.dashboard'));
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('admin.login');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/DashboardController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+
+class DashboardController extends Controller
+{
+    public function __invoke(): View
+    {
+        return view('admin.dashboard');
+    }
+}

--- a/hotel-reservation/src/app/Models/Admin.php
+++ b/hotel-reservation/src/app/Models/Admin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class Admin extends Authenticatable
+{
+    protected $fillable = [
+        'last_name',
+        'first_name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+}

--- a/hotel-reservation/src/bootstrap/app.php
+++ b/hotel-reservation/src/bootstrap/app.php
@@ -11,7 +11,12 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->redirectGuestsTo(function (\Illuminate\Http\Request $request) {
+            if ($request->is('admin/*')) {
+                return route('admin.login');
+            }
+            return route('login');
+        });
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/hotel-reservation/src/config/auth.php
+++ b/hotel-reservation/src/config/auth.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Admin;
 use App\Models\User;
 
 return [
@@ -42,6 +43,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -65,6 +70,10 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', User::class),
+        ],
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => Admin::class,
         ],
 
         // 'users' => [

--- a/hotel-reservation/src/database/seeders/AdminSeeder.php
+++ b/hotel-reservation/src/database/seeders/AdminSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Admin;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class AdminSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Admin::create([
+            'last_name' => '山田',
+            'first_name' => '太郎',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+        ]);
+    }
+}

--- a/hotel-reservation/src/database/seeders/DatabaseSeeder.php
+++ b/hotel-reservation/src/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,11 +14,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(AdminSeeder::class);
     }
 }

--- a/hotel-reservation/src/resources/views/admin/auth/login.blade.php
+++ b/hotel-reservation/src/resources/views/admin/auth/login.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>管理者ログイン</title>
+</head>
+<body>
+    <h1>管理者ログイン</h1>
+
+    @if ($errors->any())
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+
+    <form method="POST" action="{{ route('admin.login.store') }}">
+        @csrf
+        <div>
+            <label for="email">メールアドレス</label>
+            <input type="email" id="email" name="email" value="{{ old('email') }}" required>
+        </div>
+        <div>
+            <label for="password">パスワード</label>
+            <input type="password" id="password" name="password" required>
+        </div>
+        <button type="submit">ログイン</button>
+    </form>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/admin/dashboard.blade.php
+++ b/hotel-reservation/src/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>管理者ダッシュボード</title>
+</head>
+<body>
+    <h1>管理者ダッシュボード</h1>
+    <p>ログイン中: {{ Auth::guard('admin')->user()->last_name }} {{ Auth::guard('admin')->user()->first_name }}</p>
+    <form method="POST" action="{{ route('admin.logout') }}">
+        @csrf
+        @method('DELETE')
+        <button type="submit">ログアウト</button>
+    </form>
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -1,7 +1,23 @@
 <?php
 
+use App\Http\Controllers\Admin\Auth\LoginController;
+use App\Http\Controllers\Admin\DashboardController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+Route::prefix('admin')->name('admin.')->group(function () {
+    // ゲストのみアクセス可
+    Route::middleware('guest:admin')->group(function () {
+        Route::get('login', [LoginController::class, 'show'])->name('login');
+        Route::post('login', [LoginController::class, 'store'])->name('login.store');
+    });
+
+    // 認証済みのみアクセス可
+    Route::middleware('auth:admin')->group(function () {
+        Route::get('dashboard', DashboardController::class)->name('dashboard');
+        Route::delete('logout', [LoginController::class, 'destroy'])->name('logout');
+    });
 });

--- a/hotel-reservation/src/tests/Feature/Admin/Auth/LoginTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Auth/LoginTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Admin\Auth;
+
+use App\Models\Admin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ログインフォームが表示される(): void
+    {
+        $this->get(route('admin.login'))
+            ->assertStatus(200);
+    }
+
+    public function test_正しい認証情報でログインできる(): void
+    {
+        $admin = Admin::create([
+            'last_name' => '山田',
+            'first_name' => '太郎',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $this->post(route('admin.login.store'), [
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ])
+            ->assertRedirect(route('admin.dashboard'));
+
+        $this->assertAuthenticatedAs($admin, 'admin');
+    }
+
+    public function test_間違った認証情報ではログインできない(): void
+    {
+        Admin::create([
+            'last_name' => '山田',
+            'first_name' => '太郎',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $this->post(route('admin.login.store'), [
+            'email' => 'admin@example.com',
+            'password' => 'wrong-password',
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('email');
+
+        $this->assertGuest('admin');
+    }
+
+    public function test_未認証でダッシュボードにアクセスするとログイン画面にリダイレクトされる(): void
+    {
+        $this->get(route('admin.dashboard'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_ログアウトできる(): void
+    {
+        $admin = Admin::create([
+            'last_name' => '山田',
+            'first_name' => '太郎',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        $this->actingAs($admin, 'admin')
+            ->delete(route('admin.logout'))
+            ->assertRedirect(route('admin.login'));
+
+        $this->assertGuest('admin');
+    }
+}


### PR DESCRIPTION
## 概要

カスタムガード（`admin`）を使い、`admins` テーブルで管理者認証を行う構成を実装。

Closes #54

## Breeze を使わない理由

Breeze は `users` ガード前提で一式生成するため、カスタムガードへの読み替えコストが高い。
管理者はシーダー登録のみでパスワードリセット不要・宿泊者ログインも MVP スコープ外のため、Breeze の恩恵がない。

## 実装内容

- `config/auth.php` に `admin` ガード・`admins` プロバイダーを追加
- `Admin` Model 作成（`Authenticatable` を継承）
- `AdminSeeder` で初期管理者データを挿入（`admin@example.com` / `password`）
- `Admin/Auth/LoginController` でログイン・ログアウトを実装
- `Admin/DashboardController` でダッシュボードを実装
- `admin` プレフィックスのルートを定義し、`auth:admin` ミドルウェアで保護
- `bootstrap/app.php` で `admin/*` へのゲストアクセスを `admin.login` へリダイレクト設定

## テスト

`LoginTest`（5件）をすべてパス:
- ログインフォームが表示される
- 正しい認証情報でログインできる
- 間違った認証情報ではログインできない
- 未認証でダッシュボードにアクセスするとログイン画面にリダイレクトされる
- ログアウトできる