### PR TITLE
chore: pre-commitフックにテスト実行を追加（Issue #59）

### DIFF
--- a/hotel-reservation/src/captainhook.json
+++ b/hotel-reservation/src/captainhook.json
@@ -15,6 +15,11 @@
                 "action": "php vendor/bin/phpstan analyse",
                 "options": [],
                 "conditions": []
+            },
+            {
+                "action": "php artisan test",
+                "options": [],
+                "conditions": []
             }
         ]
     },


### PR DESCRIPTION
## 概要

pre-commit フックに `php artisan test` を追加し、コミット前にテスト失敗を検出できるようにする。

Closes #59

## 変更内容

`captainhook.json` にテストアクションを追加。
`.git/hooks/pre-commit` にも直接反映済み（Sail 環境では `captainhook install` が使えないため手動管理）。

### 変更後のフロー

```
PHP CS Fixer → PHPStan → php artisan test → コミット
```

## 確認

コミット時にテストが実行され、7件全件パスすることを確認済み。