### PR TITLE
feat: ReservationService TDD実装（Issue #56）

### DIFF
--- a/hotel-reservation/src/app/Services/ReservationService.php
+++ b/hotel-reservation/src/app/Services/ReservationService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use Illuminate\Support\Facades\DB;
+
+class ReservationService
+{
+    /** @param array<string, mixed> $guestData */
+    public function reserve(ReservationSlot $slot, AccommodationPlan $plan, array $guestData): Reservation
+    {
+        if ($slot->status !== 1) {
+            throw new \RuntimeException('この予約枠はすでに埋まっています。');
+        }
+
+        $price = PlanRoomPrice::where('room_type_id', $slot->room_type_id)
+            ->where('accommodation_plan_id', $plan->id)
+            ->value('price');
+
+        if ($price === null) {
+            throw new \RuntimeException('この部屋タイプとプランの組み合わせの料金が設定されていません。');
+        }
+
+        return DB::transaction(function () use ($slot, $plan, $price, $guestData): Reservation {
+            $slot->update(['status' => 2]);
+
+            return Reservation::create(array_merge([
+                'reservation_slot_id'   => $slot->id,
+                'accommodation_plan_id' => $plan->id,
+                'plan_name'             => $plan->name,
+                'price'                 => $price,
+            ], $guestData));
+        });
+    }
+
+    public function cancel(Reservation $reservation): void
+    {
+        DB::transaction(function () use ($reservation): void {
+            $reservation->update(['status' => 2]);
+            $reservation->reservationSlot()->update(['status' => 1]);
+        });
+    }
+}

--- a/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use App\Services\ReservationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ReservationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationService();
+    }
+
+    /** @return array<string, mixed> */
+    private function guestData(array $overrides = []): array
+    {
+        return array_merge([
+            'last_name'  => '山田',
+            'first_name' => '太郎',
+            'email'      => 'taro@example.com',
+            'address'    => '東京都新宿区1-1-1',
+            'phone'      => '0312345678',
+            'message'    => null,
+        ], $overrides);
+    }
+
+    public function test_正常に予約が作成できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $slot->room_type_id,
+            'price'                 => 10000,
+        ]);
+
+        $reservation = $this->service->reserve($slot, $plan, $this->guestData());
+
+        $this->assertInstanceOf(Reservation::class, $reservation);
+        $this->assertDatabaseHas('reservations', [
+            'reservation_slot_id'  => $slot->id,
+            'accommodation_plan_id' => $plan->id,
+        ]);
+    }
+
+    public function test_予約確定時にplan_nameとpriceのスナップショットが保存される(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => 'スタンダードプラン']);
+        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $slot->room_type_id,
+            'price'                 => 15000,
+        ]);
+
+        $reservation = $this->service->reserve($slot, $plan, $this->guestData());
+
+        $this->assertSame('スタンダードプラン', $reservation->plan_name);
+        $this->assertSame(15000, $reservation->price);
+    }
+
+    public function test_予約済みの枠には予約できない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create(['status' => 2]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $slot->room_type_id,
+            'price'                 => 10000,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->service->reserve($slot, $plan, $this->guestData());
+    }
+
+    public function test_予約確定時に予約枠のステータスが埋まっているに更新される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $slot->room_type_id,
+            'price'                 => 10000,
+        ]);
+
+        $this->service->reserve($slot, $plan, $this->guestData());
+
+        $this->assertSame(2, $slot->fresh()->status);
+    }
+
+    public function test_予約キャンセル時に予約枠が解放される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create(['status' => 2]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $slot->room_type_id,
+            'price'                 => 10000,
+        ]);
+        $reservation = Reservation::factory()->create([
+            'reservation_slot_id'   => $slot->id,
+            'accommodation_plan_id' => $plan->id,
+            'status'                => 1,
+        ]);
+
+        $this->service->cancel($reservation);
+
+        $this->assertSame(1, $slot->fresh()->status);
+        $this->assertSame(2, $reservation->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary

- `ReservationService` を TDD で実装（テスト先行→実装の順）
- `reserve()`: 予約枠の空き確認 → `PlanRoomPrice` から価格取得 → トランザクション内で `Reservation` 作成 + 枠を「埋まっている」に更新
- `cancel()`: トランザクション内で予約をキャンセル済みに、枠を空きに戻す

## Test plan

- [x] `test_正常に予約が作成できる`
- [x] `test_予約確定時にplan_nameとpriceのスナップショットが保存される`（設計の肝）
- [x] `test_予約済みの枠には予約できない`（重複防止）
- [x] `test_予約確定時に予約枠のステータスが埋まっているに更新される`
- [x] `test_予約キャンセル時に予約枠が解放される`
- [x] PHPStan level 6 パス
- [x] PHP CS Fixer パス

## 備考

status のマジックナンバー（`1`/`2`）は #62（enum リファクタリング）で解消予定。

Closes #56