### PR TITLE
refactor: statusフィールドをPHP enumで型安全にする（Issue #62）

### DIFF
--- a/hotel-reservation/src/app/Enums/InquiryStatus.php
+++ b/hotel-reservation/src/app/Enums/InquiryStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum InquiryStatus: int
+{
+    case Unread = 1;
+    case Read   = 2;
+}

--- a/hotel-reservation/src/app/Enums/ReservationSlotStatus.php
+++ b/hotel-reservation/src/app/Enums/ReservationSlotStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ReservationSlotStatus: int
+{
+    case Available = 1;
+    case Booked    = 2;
+}

--- a/hotel-reservation/src/app/Enums/ReservationStatus.php
+++ b/hotel-reservation/src/app/Enums/ReservationStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ReservationStatus: int
+{
+    case Confirmed  = 1;
+    case Cancelled  = 2;
+}

--- a/hotel-reservation/src/app/Models/Inquiry.php
+++ b/hotel-reservation/src/app/Models/Inquiry.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\InquiryStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -18,5 +19,9 @@ class Inquiry extends Model
         'phone',
         'message',
         'status',
+    ];
+
+    protected $casts = [
+        'status' => InquiryStatus::class,
     ];
 }

--- a/hotel-reservation/src/app/Models/Reservation.php
+++ b/hotel-reservation/src/app/Models/Reservation.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ReservationStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,6 +25,10 @@ class Reservation extends Model
         'message',
         'status',
         'memo',
+    ];
+
+    protected $casts = [
+        'status' => ReservationStatus::class,
     ];
 
     /** @return BelongsTo<ReservationSlot, $this> */

--- a/hotel-reservation/src/app/Models/ReservationSlot.php
+++ b/hotel-reservation/src/app/Models/ReservationSlot.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ReservationSlotStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,8 +16,9 @@ class ReservationSlot extends Model
     protected $fillable = ['room_type_id', 'status', 'start', 'end'];
 
     protected $casts = [
-        'start' => 'date',
-        'end' => 'date',
+        'status' => ReservationSlotStatus::class,
+        'start'  => 'date',
+        'end'    => 'date',
     ];
 
     /** @return BelongsTo<RoomType, $this> */

--- a/hotel-reservation/src/app/Services/ReservationService.php
+++ b/hotel-reservation/src/app/Services/ReservationService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Enums\ReservationSlotStatus;
+use App\Enums\ReservationStatus;
 use App\Models\AccommodationPlan;
 use App\Models\PlanRoomPrice;
 use App\Models\Reservation;
@@ -13,7 +15,7 @@ class ReservationService
     /** @param array<string, mixed> $guestData */
     public function reserve(ReservationSlot $slot, AccommodationPlan $plan, array $guestData): Reservation
     {
-        if ($slot->status !== 1) {
+        if ($slot->status !== ReservationSlotStatus::Available) {
             throw new \RuntimeException('この予約枠はすでに埋まっています。');
         }
 
@@ -26,7 +28,7 @@ class ReservationService
         }
 
         return DB::transaction(function () use ($slot, $plan, $price, $guestData): Reservation {
-            $slot->update(['status' => 2]);
+            $slot->update(['status' => ReservationSlotStatus::Booked]);
 
             return Reservation::create(array_merge([
                 'reservation_slot_id'   => $slot->id,
@@ -40,8 +42,8 @@ class ReservationService
     public function cancel(Reservation $reservation): void
     {
         DB::transaction(function () use ($reservation): void {
-            $reservation->update(['status' => 2]);
-            $reservation->reservationSlot()->update(['status' => 1]);
+            $reservation->update(['status' => ReservationStatus::Cancelled]);
+            $reservation->reservationSlot()->update(['status' => ReservationSlotStatus::Available]);
         });
     }
 }

--- a/hotel-reservation/src/database/factories/InquiryFactory.php
+++ b/hotel-reservation/src/database/factories/InquiryFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\InquiryStatus;
 use App\Models\Inquiry;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -24,7 +25,7 @@ class InquiryFactory extends Factory
             'address' => $this->faker->address(),
             'phone' => $this->faker->phoneNumber(),
             'message' => $this->faker->optional()->sentence(),
-            'status' => 1,
+            'status' => InquiryStatus::Unread,
         ];
     }
 }

--- a/hotel-reservation/src/database/factories/ReservationFactory.php
+++ b/hotel-reservation/src/database/factories/ReservationFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ReservationStatus;
 use App\Models\AccommodationPlan;
 use App\Models\Reservation;
 use App\Models\ReservationSlot;
@@ -30,7 +31,7 @@ class ReservationFactory extends Factory
             'address' => $this->faker->address(),
             'phone' => $this->faker->phoneNumber(),
             'message' => $this->faker->optional()->sentence(),
-            'status' => 1,
+            'status' => ReservationStatus::Confirmed,
             'memo' => null,
         ];
     }

--- a/hotel-reservation/src/database/factories/ReservationSlotFactory.php
+++ b/hotel-reservation/src/database/factories/ReservationSlotFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ReservationSlotStatus;
 use App\Models\ReservationSlot;
 use App\Models\RoomType;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -23,7 +24,7 @@ class ReservationSlotFactory extends Factory
 
         return [
             'room_type_id' => RoomType::factory(),
-            'status' => 1,
+            'status' => ReservationSlotStatus::Available,
             'start' => $start->format('Y-m-d'),
             'end' => $end->format('Y-m-d'),
         ];

--- a/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Services;
 
+use App\Enums\ReservationSlotStatus;
+use App\Enums\ReservationStatus;
 use App\Models\AccommodationPlan;
 use App\Models\PlanRoomPrice;
 use App\Models\Reservation;
@@ -38,7 +40,7 @@ class ReservationServiceTest extends TestCase
     public function test_正常に予約が作成できる(): void
     {
         $plan = AccommodationPlan::factory()->create();
-        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
             'room_type_id'          => $slot->room_type_id,
@@ -57,7 +59,7 @@ class ReservationServiceTest extends TestCase
     public function test_予約確定時にplan_nameとpriceのスナップショットが保存される(): void
     {
         $plan = AccommodationPlan::factory()->create(['name' => 'スタンダードプラン']);
-        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
             'room_type_id'          => $slot->room_type_id,
@@ -73,7 +75,7 @@ class ReservationServiceTest extends TestCase
     public function test_予約済みの枠には予約できない(): void
     {
         $plan = AccommodationPlan::factory()->create();
-        $slot = ReservationSlot::factory()->create(['status' => 2]);
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Booked]);
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
             'room_type_id'          => $slot->room_type_id,
@@ -88,7 +90,7 @@ class ReservationServiceTest extends TestCase
     public function test_予約確定時に予約枠のステータスが埋まっているに更新される(): void
     {
         $plan = AccommodationPlan::factory()->create();
-        $slot = ReservationSlot::factory()->create(['status' => 1]);
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
             'room_type_id'          => $slot->room_type_id,
@@ -97,13 +99,13 @@ class ReservationServiceTest extends TestCase
 
         $this->service->reserve($slot, $plan, $this->guestData());
 
-        $this->assertSame(2, $slot->fresh()->status);
+        $this->assertSame(ReservationSlotStatus::Booked, $slot->fresh()->status);
     }
 
     public function test_予約キャンセル時に予約枠が解放される(): void
     {
         $plan = AccommodationPlan::factory()->create();
-        $slot = ReservationSlot::factory()->create(['status' => 2]);
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Booked]);
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
             'room_type_id'          => $slot->room_type_id,
@@ -112,12 +114,12 @@ class ReservationServiceTest extends TestCase
         $reservation = Reservation::factory()->create([
             'reservation_slot_id'   => $slot->id,
             'accommodation_plan_id' => $plan->id,
-            'status'                => 1,
+            'status'                => ReservationStatus::Confirmed,
         ]);
 
         $this->service->cancel($reservation);
 
-        $this->assertSame(1, $slot->fresh()->status);
-        $this->assertSame(2, $reservation->fresh()->status);
+        $this->assertSame(ReservationSlotStatus::Available, $slot->fresh()->status);
+        $this->assertSame(ReservationStatus::Cancelled, $reservation->fresh()->status);
     }
 }


### PR DESCRIPTION
## Summary

- `reservation_slots.status` / `reservations.status` / `inquiries.status` のマジックナンバー（`1`/`2`）を PHP Backed Enum に置換
- モデルの `$casts` に Enum を設定し、Laravel が自動でキャスト

追加した Enum:
| クラス | Available/Confirmed/Unread | Booked/Cancelled/Read |
|---|---|---|
| `ReservationSlotStatus` | `Available = 1` | `Booked = 2` |
| `ReservationStatus` | `Confirmed = 1` | `Cancelled = 2` |
| `InquiryStatus` | `Unread = 1` | `Read = 2` |

## Test plan

- [x] 全テスト 12/12 パス
- [x] PHPStan level 6 パス
- [x] PHP CS Fixer パス

Closes #62