### PR TITLE
test: 料金未設定時の予約不可テストを追加（Issue #65）

### DIFF
--- a/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
@@ -122,4 +122,15 @@ class ReservationServiceTest extends TestCase
         $this->assertSame(ReservationSlotStatus::Available, $slot->fresh()->status);
         $this->assertSame(ReservationStatus::Cancelled, $reservation->fresh()->status);
     }
+
+    public function test_料金が設定されていない場合は予約できない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
+        // PlanRoomPrice を作らない
+
+        $this->expectException(\RuntimeException::class);
+
+        $this->service->reserve($slot, $plan, $this->guestData());
+    }
 }


### PR DESCRIPTION
## Summary

- `ReservationService::reserve()` で `PlanRoomPrice` が存在しない場合に `RuntimeException` が投げられることを確認するテストを追加
- 実装済みのガード節に対応するテストが抜けていたため補完

## Test plan

- [x] `test_料金が設定されていない場合は予約できない` 追加
- [x] 全テスト 13/13 パス
- [x] PHPStan level 6 パス
- [x] PHP CS Fixer パス

Closes #65