### PR TITLE
feat: Controller接続・シンプルUI実装（Issue #57）

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Reservation;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use App\Services\ReservationService;
+use Illuminate\Http\RedirectResponse;
+
+class CancelController extends Controller
+{
+    public function __invoke(Reservation $reservation, ReservationService $service): RedirectResponse
+    {
+        $service->cancel($reservation);
+
+        return redirect()->route('admin.reservations.index')->with('success', '予約をキャンセルしました。');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/IndexController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Reservation;
+
+use App\Http\Controllers\Controller;
+use App\Models\Reservation;
+use Illuminate\View\View;
+
+class IndexController extends Controller
+{
+    public function __invoke(): View
+    {
+        $reservations = Reservation::with(['reservationSlot.roomType', 'accommodationPlan'])
+            ->latest()
+            ->paginate(20);
+
+        return view('admin.reservation.index', compact('reservations'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/ConfirmController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/ConfirmController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\User\Reservation;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\ReservationSlot;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ConfirmController extends Controller
+{
+    public function __invoke(Request $request): View
+    {
+        $validated = $request->validate([
+            'slot_id'    => 'required|exists:reservation_slots,id',
+            'plan_id'    => 'required|exists:accommodation_plans,id',
+            'last_name'  => 'required|string|max:255',
+            'first_name' => 'required|string|max:255',
+            'email'      => 'required|email|max:255',
+            'address'    => 'required|string|max:255',
+            'phone'      => 'required|string|max:20',
+            'message'    => 'nullable|string',
+        ]);
+
+        $slot  = ReservationSlot::findOrFail($validated['slot_id']);
+        $plan  = AccommodationPlan::findOrFail($validated['plan_id']);
+        $price = PlanRoomPrice::where('room_type_id', $slot->room_type_id)
+            ->where('accommodation_plan_id', $plan->id)
+            ->value('price');
+
+        return view('user.reservation.confirm', compact('slot', 'plan', 'price', 'validated'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/CreateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/CreateController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\User\Reservation;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\ReservationSlot;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class CreateController extends Controller
+{
+    public function __invoke(Request $request): View
+    {
+        $slot = ReservationSlot::findOrFail($request->query('slot_id'));
+        $plan = AccommodationPlan::findOrFail($request->query('plan_id'));
+
+        $price = PlanRoomPrice::where('room_type_id', $slot->room_type_id)
+            ->where('accommodation_plan_id', $plan->id)
+            ->value('price');
+
+        return view('user.reservation.create', compact('slot', 'plan', 'price'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\User\Reservation;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Models\ReservationSlot;
+use App\Services\ReservationService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class StoreController extends Controller
+{
+    public function __invoke(Request $request, ReservationService $service): RedirectResponse
+    {
+        $validated = $request->validate([
+            'slot_id'    => 'required|exists:reservation_slots,id',
+            'plan_id'    => 'required|exists:accommodation_plans,id',
+            'last_name'  => 'required|string|max:255',
+            'first_name' => 'required|string|max:255',
+            'email'      => 'required|email|max:255',
+            'address'    => 'required|string|max:255',
+            'phone'      => 'required|string|max:20',
+            'message'    => 'nullable|string',
+        ]);
+
+        $slot = ReservationSlot::findOrFail($validated['slot_id']);
+        $plan = AccommodationPlan::findOrFail($validated['plan_id']);
+
+        $guestData = array_diff_key($validated, ['slot_id' => '', 'plan_id' => '']);
+
+        try {
+            $service->reserve($slot, $plan, $guestData);
+        } catch (\RuntimeException $e) {
+            return back()->withErrors(['slot_id' => $e->getMessage()]);
+        }
+
+        return redirect()->route('user.reservations.complete');
+    }
+}

--- a/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約一覧（管理者）</title>
+</head>
+<body>
+<h1>予約一覧</h1>
+
+@if (session('success'))
+    <p style="color:green">{{ session('success') }}</p>
+@endif
+
+<table border="1" cellpadding="8">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>宿泊者</th>
+            <th>プラン</th>
+            <th>部屋タイプ</th>
+            <th>日程</th>
+            <th>料金</th>
+            <th>ステータス</th>
+            <th>操作</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($reservations as $reservation)
+            <tr>
+                <td>{{ $reservation->id }}</td>
+                <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
+                <td>{{ $reservation->plan_name }}</td>
+                <td>{{ $reservation->reservationSlot->roomType->name }}</td>
+                <td>
+                    {{ $reservation->reservationSlot->start->format('Y/m/d') }}
+                    〜
+                    {{ $reservation->reservationSlot->end->format('Y/m/d') }}
+                </td>
+                <td>{{ number_format($reservation->price) }}円</td>
+                <td>{{ $reservation->status->name }}</td>
+                <td>
+                    @if ($reservation->status === \App\Enums\ReservationStatus::Confirmed)
+                        <form action="{{ route('admin.reservations.cancel', $reservation) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" onclick="return confirm('キャンセルしますか？')">キャンセル</button>
+                        </form>
+                    @else
+                        —
+                    @endif
+                </td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>
+
+{{ $reservations->links() }}
+
+<p><a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a></p>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約完了</title>
+</head>
+<body>
+<h1>予約が完了しました</h1>
+<p>ご予約ありがとうございます。確認メールをお送りします。</p>
+<a href="/">TOPページへ</a>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約内容確認</title>
+</head>
+<body>
+<h1>予約内容確認</h1>
+<p>以下の内容で予約を確定します。よろしければ「予約を確定する」ボタンを押してください。</p>
+
+<table border="1">
+    <tr><th>プラン</th><td>{{ $plan->name }}</td></tr>
+    <tr><th>日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
+    <tr><th>料金</th><td>{{ number_format($price) }}円</td></tr>
+    <tr><th>氏名</th><td>{{ $validated['last_name'] }} {{ $validated['first_name'] }}</td></tr>
+    <tr><th>メールアドレス</th><td>{{ $validated['email'] }}</td></tr>
+    <tr><th>住所</th><td>{{ $validated['address'] }}</td></tr>
+    <tr><th>電話番号</th><td>{{ $validated['phone'] }}</td></tr>
+    <tr><th>メッセージ</th><td>{{ $validated['message'] ?? '—' }}</td></tr>
+</table>
+
+<form action="{{ route('user.reservations.store') }}" method="POST">
+    @csrf
+    @foreach ($validated as $key => $value)
+        <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+    @endforeach
+    <button type="submit">予約を確定する</button>
+</form>
+
+<a href="{{ route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]) }}">← 入力に戻る</a>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/reservation/create.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/create.blade.php
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約フォーム</title>
+</head>
+<body>
+<h1>予約フォーム</h1>
+
+<table border="1">
+    <tr><th>プラン</th><td>{{ $plan->name }}</td></tr>
+    <tr><th>日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
+    <tr><th>料金</th><td>{{ number_format($price) }}円</td></tr>
+</table>
+
+@if ($errors->any())
+    <ul style="color:red">
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif
+
+<form action="{{ route('user.reservations.confirm') }}" method="POST">
+    @csrf
+    <input type="hidden" name="slot_id" value="{{ $slot->id }}">
+    <input type="hidden" name="plan_id" value="{{ $plan->id }}">
+
+    <p>
+        <label>姓：<input type="text" name="last_name" value="{{ old('last_name') }}" required></label>
+        <label>名：<input type="text" name="first_name" value="{{ old('first_name') }}" required></label>
+    </p>
+    <p><label>メールアドレス：<input type="email" name="email" value="{{ old('email') }}" required></label></p>
+    <p><label>住所：<input type="text" name="address" value="{{ old('address') }}" required size="50"></label></p>
+    <p><label>電話番号：<input type="tel" name="phone" value="{{ old('phone') }}" required></label></p>
+    <p><label>ホテルへのメッセージ：<br><textarea name="message" rows="4" cols="50">{{ old('message') }}</textarea></label></p>
+
+    <button type="submit">確認画面へ</button>
+</form>
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -2,10 +2,23 @@
 
 use App\Http\Controllers\Admin\Auth\LoginController;
 use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\Reservation\CancelController as AdminReservationCancelController;
+use App\Http\Controllers\Admin\Reservation\IndexController as AdminReservationIndexController;
+use App\Http\Controllers\User\Reservation\ConfirmController as UserReservationConfirmController;
+use App\Http\Controllers\User\Reservation\CreateController as UserReservationCreateController;
+use App\Http\Controllers\User\Reservation\StoreController as UserReservationStoreController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+// 宿泊者：予約フロー（認証不要）
+Route::prefix('reservations')->name('user.reservations.')->group(function () {
+    Route::get('create', UserReservationCreateController::class)->name('create');
+    Route::post('confirm', UserReservationConfirmController::class)->name('confirm');
+    Route::post('/', UserReservationStoreController::class)->name('store');
+    Route::get('complete', fn () => view('user.reservation.complete'))->name('complete');
 });
 
 Route::prefix('admin')->name('admin.')->group(function () {
@@ -19,5 +32,11 @@ Route::prefix('admin')->name('admin.')->group(function () {
     Route::middleware('auth:admin')->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
         Route::delete('logout', [LoginController::class, 'destroy'])->name('logout');
+
+        // 予約管理
+        Route::prefix('reservations')->name('reservations.')->group(function () {
+            Route::get('/', AdminReservationIndexController::class)->name('index');
+            Route::delete('{reservation}/cancel', AdminReservationCancelController::class)->name('cancel');
+        });
     });
 });


### PR DESCRIPTION
## Summary

ReservationService を Controller に接続し、予約フロー全体を動作確認できる最低限の UI を実装。

### 宿泊者側（認証不要）
- `CreateController` — 仮入り口（`?slot_id=X&plan_id=Y` で予約フォームにアクセス）
- `ConfirmController` — 入力値を受け取り確認画面を表示
- `StoreController` — `ReservationService::reserve()` を呼び予約を確定（枠が埋まっている場合はエラー表示）

### 管理者側（`auth:admin` で保護）
- `IndexController` — 予約一覧（宿泊者・プラン・日程・料金・ステータス表示）
- `CancelController` — `ReservationService::cancel()` を呼びキャンセル処理

## Test plan

- [x] ブラウザで予約フォーム → 確認 → 完了フローを動作確認
- [x] 管理者ログイン後に予約一覧・キャンセルが動作することを確認
- [x] 全テスト 13/13 パス
- [x] PHPStan level 6 パス
- [x] PHP CS Fixer パス

Closes #57