### PR TITLE
feat: 予約枠管理機能を実装（Issue #69）

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/BulkStoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/BulkStoreController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\RoomType;
+use App\Services\ReservationSlotService;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class BulkStoreController extends Controller
+{
+    public function __invoke(Request $request, ReservationSlotService $service): RedirectResponse
+    {
+        $validated = $request->validate([
+            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
+            'from'         => ['required', 'date', 'before:to'],
+            'to'           => ['required', 'date', 'after:from'],
+        ]);
+
+        $roomType = RoomType::findOrFail($validated['room_type_id']);
+        $created  = $service->bulkStore(
+            $roomType,
+            Carbon::parse($validated['from']),
+            Carbon::parse($validated['to'])
+        );
+
+        return redirect()->route('admin.reservation-slots.index')
+            ->with('success', "{$created}件の予約枠を作成しました。");
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/DestroyController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/DestroyController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReservationSlot;
+use App\Services\ReservationSlotService;
+use Illuminate\Http\RedirectResponse;
+
+class DestroyController extends Controller
+{
+    public function __invoke(ReservationSlot $reservationSlot, ReservationSlotService $service): RedirectResponse
+    {
+        try {
+            $service->destroy($reservationSlot);
+        } catch (\RuntimeException $e) {
+            return back()->with('error', $e->getMessage());
+        }
+
+        return redirect()->route('admin.reservation-slots.index')->with('success', '予約枠を削除しました。');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/EditController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/EditController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Illuminate\Contracts\View\View;
+
+class EditController extends Controller
+{
+    public function __invoke(ReservationSlot $reservationSlot): View
+    {
+        $roomTypes = RoomType::orderBy('id')->get();
+
+        return view('admin.reservation-slot.edit', compact('reservationSlot', 'roomTypes'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/IndexController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class IndexController extends Controller
+{
+    public function __invoke(Request $request): View
+    {
+        $slots = ReservationSlot::with('roomType')
+            ->orderBy('start')
+            ->orderBy('room_type_id')
+            ->paginate(20);
+
+        $roomTypes = RoomType::orderBy('id')->get();
+
+        return view('admin.reservation-slot.index', compact('slots', 'roomTypes'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/StoreController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\RoomType;
+use App\Services\ReservationSlotService;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class StoreController extends Controller
+{
+    public function __invoke(Request $request, ReservationSlotService $service): RedirectResponse
+    {
+        $validated = $request->validate([
+            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
+            'start'        => ['required', 'date', 'before:end'],
+            'end'          => ['required', 'date', 'after:start'],
+        ]);
+
+        $roomType = RoomType::findOrFail($validated['room_type_id']);
+
+        try {
+            $service->store($roomType, Carbon::parse($validated['start']), Carbon::parse($validated['end']));
+        } catch (\RuntimeException $e) {
+            return back()->withInput()->with('error', $e->getMessage());
+        }
+
+        return redirect()->route('admin.reservation-slots.index')->with('success', '予約枠を作成しました。');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/UpdateController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Admin\ReservationSlot;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use App\Services\ReservationSlotService;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class UpdateController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        ReservationSlot $reservationSlot,
+        ReservationSlotService $service
+    ): RedirectResponse {
+        $validated = $request->validate([
+            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
+            'start'        => ['required', 'date', 'before:end'],
+            'end'          => ['required', 'date', 'after:start'],
+        ]);
+
+        $roomType = RoomType::findOrFail($validated['room_type_id']);
+
+        try {
+            $service->update(
+                $reservationSlot,
+                $roomType,
+                Carbon::parse($validated['start']),
+                Carbon::parse($validated['end'])
+            );
+        } catch (\RuntimeException $e) {
+            return back()->withInput()->with('error', $e->getMessage());
+        }
+
+        return redirect()->route('admin.reservation-slots.index')->with('success', '予約枠を更新しました。');
+    }
+}

--- a/hotel-reservation/src/app/Services/ReservationSlotService.php
+++ b/hotel-reservation/src/app/Services/ReservationSlotService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Carbon\Carbon;
+
+class ReservationSlotService
+{
+    public function store(RoomType $roomType, Carbon $start, Carbon $end): ReservationSlot
+    {
+        $this->assertCapacityAvailable($roomType, $start, $end);
+
+        return ReservationSlot::create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Available,
+            'start'        => $start->toDateString(),
+            'end'          => $end->toDateString(),
+        ]);
+    }
+
+    public function bulkStore(RoomType $roomType, Carbon $from, Carbon $to): int
+    {
+        $created = 0;
+        $current = $from->copy();
+
+        while ($current->lt($to)) {
+            $start = $current->copy();
+            $end   = $current->copy()->addDay();
+            try {
+                $this->store($roomType, $start, $end);
+                $created++;
+            } catch (\RuntimeException) {
+                // 定員に達している日程はスキップ
+            }
+            $current->addDay();
+        }
+
+        return $created;
+    }
+
+    public function update(ReservationSlot $slot, RoomType $roomType, Carbon $start, Carbon $end): void
+    {
+        if ($slot->status === ReservationSlotStatus::Booked) {
+            throw new \RuntimeException('予約済みの枠は編集できません。');
+        }
+
+        $existing = ReservationSlot::where('room_type_id', $roomType->id)
+            ->where('start', $start->toDateString())
+            ->where('end', $end->toDateString())
+            ->where('id', '!=', $slot->id)
+            ->count();
+
+        if ($existing >= $roomType->count) {
+            throw new \RuntimeException('この部屋タイプ・日程の予約枠は定員に達しています。');
+        }
+
+        $slot->update([
+            'room_type_id' => $roomType->id,
+            'start'        => $start->toDateString(),
+            'end'          => $end->toDateString(),
+        ]);
+    }
+
+    public function destroy(ReservationSlot $slot): void
+    {
+        if ($slot->reservation()->exists()) {
+            throw new \RuntimeException('予約が入っている枠は削除できません。');
+        }
+
+        $slot->delete();
+    }
+
+    private function assertCapacityAvailable(RoomType $roomType, Carbon $start, Carbon $end): void
+    {
+        $existing = ReservationSlot::where('room_type_id', $roomType->id)
+            ->where('start', $start->toDateString())
+            ->where('end', $end->toDateString())
+            ->count();
+
+        if ($existing >= $roomType->count) {
+            throw new \RuntimeException('この部屋タイプ・日程の予約枠は定員に達しています。');
+        }
+    }
+}

--- a/hotel-reservation/src/database/seeders/DatabaseSeeder.php
+++ b/hotel-reservation/src/database/seeders/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(AdminSeeder::class);
+        $this->call(RoomTypeSeeder::class);
     }
 }

--- a/hotel-reservation/src/database/seeders/RoomTypeSeeder.php
+++ b/hotel-reservation/src/database/seeders/RoomTypeSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\RoomType;
+use Illuminate\Database\Seeder;
+
+class RoomTypeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $types = [
+            ['name' => 'スタンダードルーム', 'count' => 3],
+            ['name' => 'デラックスルーム',  'count' => 2],
+            ['name' => 'スイートルーム',    'count' => 1],
+        ];
+
+        foreach ($types as $type) {
+            RoomType::create($type);
+        }
+    }
+}

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約枠編集</title>
+</head>
+<body>
+<h1>予約枠編集</h1>
+<a href="{{ route('admin.reservation-slots.index') }}">← 一覧へ戻る</a>
+
+@if (session('error'))
+    <p style="color:red">{{ session('error') }}</p>
+@endif
+@if ($errors->any())
+    <ul style="color:red">
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif
+
+<form action="{{ route('admin.reservation-slots.update', $reservationSlot) }}" method="POST">
+    @csrf
+    @method('PUT')
+
+    <p>
+        <label>部屋タイプ：
+            <select name="room_type_id" required>
+                @foreach ($roomTypes as $roomType)
+                    <option value="{{ $roomType->id }}"
+                        @selected(old('room_type_id', $reservationSlot->room_type_id) == $roomType->id)>
+                        {{ $roomType->name }}（{{ $roomType->count }}室）
+                    </option>
+                @endforeach
+            </select>
+        </label>
+    </p>
+    <p>
+        <label>チェックイン：
+            <input type="date" name="start"
+                   value="{{ old('start', $reservationSlot->start->format('Y-m-d')) }}" required>
+        </label>
+    </p>
+    <p>
+        <label>チェックアウト：
+            <input type="date" name="end"
+                   value="{{ old('end', $reservationSlot->end->format('Y-m-d')) }}" required>
+        </label>
+    </p>
+
+    <button type="submit">更新</button>
+</form>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約枠管理</title>
+</head>
+<body>
+<h1>予約枠管理</h1>
+<a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
+
+@if (session('success'))
+    <p style="color:green">{{ session('success') }}</p>
+@endif
+@if (session('error'))
+    <p style="color:red">{{ session('error') }}</p>
+@endif
+
+<h2>個別作成</h2>
+<form action="{{ route('admin.reservation-slots.store') }}" method="POST">
+    @csrf
+    <label>部屋タイプ：
+        <select name="room_type_id" required>
+            <option value="">選択してください</option>
+            @foreach ($roomTypes as $roomType)
+                <option value="{{ $roomType->id }}" @selected(old('room_type_id') == $roomType->id)>
+                    {{ $roomType->name }}（{{ $roomType->count }}室）
+                </option>
+            @endforeach
+        </select>
+    </label>
+    <label>チェックイン：<input type="date" name="start" value="{{ old('start') }}" required></label>
+    <label>チェックアウト：<input type="date" name="end" value="{{ old('end') }}" required></label>
+    <button type="submit">作成</button>
+</form>
+@if ($errors->any())
+    <ul style="color:red">
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif
+
+<h2>期間一括作成</h2>
+<form action="{{ route('admin.reservation-slots.bulk-store') }}" method="POST">
+    @csrf
+    <label>部屋タイプ：
+        <select name="room_type_id" required>
+            <option value="">選択してください</option>
+            @foreach ($roomTypes as $roomType)
+                <option value="{{ $roomType->id }}">
+                    {{ $roomType->name }}（{{ $roomType->count }}室）
+                </option>
+            @endforeach
+        </select>
+    </label>
+    <label>開始日：<input type="date" name="from" required></label>
+    <label>終了日（最終チェックアウト日）：<input type="date" name="to" required></label>
+    <button type="submit">一括作成</button>
+    <small>※開始日〜終了日の前日まで、1泊ずつ予約枠を作成します。定員に達した日程はスキップします。</small>
+</form>
+
+<h2>予約枠一覧</h2>
+<table border="1">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>部屋タイプ</th>
+            <th>チェックイン</th>
+            <th>チェックアウト</th>
+            <th>ステータス</th>
+            <th>操作</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse ($slots as $slot)
+            <tr>
+                <td>{{ $slot->id }}</td>
+                <td>{{ $slot->roomType->name }}</td>
+                <td>{{ $slot->start->format('Y/m/d') }}</td>
+                <td>{{ $slot->end->format('Y/m/d') }}</td>
+                <td>{{ $slot->status->name }}</td>
+                <td>
+                    @if ($slot->status->name === 'Available')
+                        <a href="{{ route('admin.reservation-slots.edit', $slot) }}">編集</a>
+                        <form action="{{ route('admin.reservation-slots.destroy', $slot) }}" method="POST" style="display:inline"
+                              onsubmit="return confirm('削除しますか？')">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit">削除</button>
+                        </form>
+                    @else
+                        予約済み
+                    @endif
+                </td>
+            </tr>
+        @empty
+            <tr><td colspan="6">予約枠がありません</td></tr>
+        @endforelse
+    </tbody>
+</table>
+
+{{ $slots->links() }}
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -4,6 +4,12 @@ use App\Http\Controllers\Admin\Auth\LoginController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\Reservation\CancelController as AdminReservationCancelController;
 use App\Http\Controllers\Admin\Reservation\IndexController as AdminReservationIndexController;
+use App\Http\Controllers\Admin\ReservationSlot\BulkStoreController as AdminReservationSlotBulkStoreController;
+use App\Http\Controllers\Admin\ReservationSlot\DestroyController as AdminReservationSlotDestroyController;
+use App\Http\Controllers\Admin\ReservationSlot\EditController as AdminReservationSlotEditController;
+use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservationSlotIndexController;
+use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
+use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
 use App\Http\Controllers\User\Reservation\ConfirmController as UserReservationConfirmController;
 use App\Http\Controllers\User\Reservation\CreateController as UserReservationCreateController;
 use App\Http\Controllers\User\Reservation\StoreController as UserReservationStoreController;
@@ -18,6 +24,7 @@ Route::prefix('reservations')->name('user.reservations.')->group(function () {
     Route::get('create', UserReservationCreateController::class)->name('create');
     Route::post('confirm', UserReservationConfirmController::class)->name('confirm');
     Route::post('/', UserReservationStoreController::class)->name('store');
+    Route::get('/', fn () => redirect('/'))->name('index');
     Route::get('complete', fn () => view('user.reservation.complete'))->name('complete');
 });
 
@@ -37,6 +44,16 @@ Route::prefix('admin')->name('admin.')->group(function () {
         Route::prefix('reservations')->name('reservations.')->group(function () {
             Route::get('/', AdminReservationIndexController::class)->name('index');
             Route::delete('{reservation}/cancel', AdminReservationCancelController::class)->name('cancel');
+        });
+
+        // 予約枠管理
+        Route::prefix('reservation-slots')->name('reservation-slots.')->group(function () {
+            Route::get('/', AdminReservationSlotIndexController::class)->name('index');
+            Route::post('/', AdminReservationSlotStoreController::class)->name('store');
+            Route::post('bulk', AdminReservationSlotBulkStoreController::class)->name('bulk-store');
+            Route::get('{reservationSlot}/edit', AdminReservationSlotEditController::class)->name('edit');
+            Route::put('{reservationSlot}', AdminReservationSlotUpdateController::class)->name('update');
+            Route::delete('{reservationSlot}', AdminReservationSlotDestroyController::class)->name('destroy');
         });
     });
 });

--- a/hotel-reservation/src/tests/Feature/Services/ReservationSlotServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/ReservationSlotServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use App\Services\ReservationSlotService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationSlotServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ReservationSlotService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReservationSlotService();
+    }
+
+    public function test_個別に予約枠を作成できる(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 3]);
+        $start = Carbon::parse('2026-06-01');
+        $end   = Carbon::parse('2026-06-02');
+
+        $slot = $this->service->store($roomType, $start, $end);
+
+        $this->assertInstanceOf(ReservationSlot::class, $slot);
+        $this->assertDatabaseHas('reservation_slots', [
+            'room_type_id' => $roomType->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available->value,
+        ]);
+    }
+
+    public function test_定員を超えた予約枠は作成できない(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 1]);
+        $start = Carbon::parse('2026-06-01');
+        $end   = Carbon::parse('2026-06-02');
+
+        // count=1 なので1枠まで作れる
+        $this->service->store($roomType, $start, $end);
+
+        // 2枠目は定員超過で例外
+        $this->expectException(\RuntimeException::class);
+        $this->service->store($roomType, $start, $end);
+    }
+
+    public function test_定員内なら同じ日程に複数枠を作成できる(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 3]);
+        $start = Carbon::parse('2026-06-01');
+        $end   = Carbon::parse('2026-06-02');
+
+        $this->service->store($roomType, $start, $end);
+        $this->service->store($roomType, $start, $end);
+        $this->service->store($roomType, $start, $end);
+
+        $this->assertDatabaseCount('reservation_slots', 3);
+    }
+
+    public function test_期間一括で予約枠を作成できる(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 3]);
+        $from = Carbon::parse('2026-07-01');
+        $to   = Carbon::parse('2026-07-04'); // 3泊分 (7/1-2, 7/2-3, 7/3-4)
+
+        $created = $this->service->bulkStore($roomType, $from, $to);
+
+        $this->assertSame(3, $created);
+        $this->assertDatabaseCount('reservation_slots', 3);
+        $this->assertDatabaseHas('reservation_slots', ['start' => '2026-07-01', 'end' => '2026-07-02']);
+        $this->assertDatabaseHas('reservation_slots', ['start' => '2026-07-02', 'end' => '2026-07-03']);
+        $this->assertDatabaseHas('reservation_slots', ['start' => '2026-07-03', 'end' => '2026-07-04']);
+    }
+
+    public function test_一括作成で定員に達した日程はスキップされる(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 1]);
+        $start = Carbon::parse('2026-07-01');
+        $end   = Carbon::parse('2026-07-02');
+
+        // 7/1の枠を先に埋める
+        $this->service->store($roomType, $start, $end);
+
+        // 7/1〜7/3で一括作成：7/1はスキップ、7/2のみ作成
+        $created = $this->service->bulkStore($roomType, Carbon::parse('2026-07-01'), Carbon::parse('2026-07-03'));
+
+        $this->assertSame(1, $created);
+        $this->assertDatabaseCount('reservation_slots', 2);
+    }
+
+    public function test_予約枠を編集できる(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 3]);
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Available,
+            'start'        => '2026-08-01',
+            'end'          => '2026-08-02',
+        ]);
+
+        $this->service->update($slot, $roomType, Carbon::parse('2026-08-10'), Carbon::parse('2026-08-11'));
+
+        $this->assertDatabaseHas('reservation_slots', [
+            'id'    => $slot->id,
+            'start' => '2026-08-10',
+            'end'   => '2026-08-11',
+        ]);
+    }
+
+    public function test_予約済みの枠は編集できない(): void
+    {
+        $roomType = RoomType::factory()->create(['count' => 3]);
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Booked,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->service->update($slot, $roomType, Carbon::parse('2026-09-01'), Carbon::parse('2026-09-02'));
+    }
+
+    public function test_予約枠を削除できる(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->service->destroy($slot);
+
+        $this->assertDatabaseMissing('reservation_slots', ['id' => $slot->id]);
+    }
+
+    public function test_予約が入っている枠は削除できない(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $plan = AccommodationPlan::factory()->create();
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Booked,
+        ]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+        Reservation::factory()->create([
+            'reservation_slot_id'   => $slot->id,
+            'accommodation_plan_id' => $plan->id,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->service->destroy($slot);
+    }
+}


### PR DESCRIPTION
## Summary

- `ReservationSlotService`（TDD）：個別作成・期間一括作成・編集・削除・重複防止（定員チェック）
- 管理者コントローラー群（who-what-whom 構成）：`Index` / `Store` / `BulkStore` / `Edit` / `Update` / `Destroy`
- `RoomTypeSeeder`：部屋マスタ初期データ（スタンダード3室・デラックス2室・スイート1室）
- `GET /reservations/` の 405 エラーをトップへのリダイレクトで修正

## Test plan

- [ ] `sail artisan test` → 22 tests passed
- [ ] PHPStan level 6 → No errors
- [ ] ブラウザで `/admin/reservation-slots` にアクセスし一覧表示を確認
- [ ] 個別作成フォームで予約枠を作成できる
- [ ] 期間一括作成で複数枠がまとめて作成される
- [ ] 定員を超えた枠は作成できない（エラーメッセージ表示）
- [ ] 編集フォームで日程・部屋タイプを変更できる
- [ ] 予約済みの枠は編集ボタンが表示されない
- [ ] 削除ボタンで枠を削除できる
- [ ] 予約が入っている枠は削除できない（エラーメッセージ表示）
- [ ] `GET /reservations/` がトップへリダイレクトされる

Closes #69