### PR TITLE
test: 管理者予約管理コントローラーのテスト追加（Issue #76）

### DIFF
--- a/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Admin\Reservation;
+
+use App\Enums\ReservationSlotStatus;
+use App\Enums\ReservationStatus;
+use App\Models\AccommodationPlan;
+use App\Models\Admin;
+use App\Models\PlanRoomPrice;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ReservationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::create([
+            'last_name'  => '山田',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+    }
+
+    // ----------------------------------------------------------------
+    // 未認証チェック
+    // ----------------------------------------------------------------
+
+    public function test_未認証ユーザーは一覧にアクセスできない(): void
+    {
+        $this->get(route('admin.reservations.index'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーはキャンセルできない(): void
+    {
+        $reservation = $this->makeConfirmedReservation();
+
+        $this->delete(route('admin.reservations.cancel', $reservation))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    // ----------------------------------------------------------------
+    // IndexController
+    // ----------------------------------------------------------------
+
+    public function test_一覧ページが表示される(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservations.index'))
+            ->assertOk();
+    }
+
+    public function test_予約データが一覧に表示される(): void
+    {
+        $reservation = $this->makeConfirmedReservation();
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservations.index'))
+            ->assertOk()
+            ->assertSee($reservation->last_name);
+    }
+
+    // ----------------------------------------------------------------
+    // CancelController
+    // ----------------------------------------------------------------
+
+    public function test_予約をキャンセルできる(): void
+    {
+        $reservation = $this->makeConfirmedReservation();
+
+        $this->actingAs($this->admin, 'admin')
+            ->delete(route('admin.reservations.cancel', $reservation))
+            ->assertRedirect(route('admin.reservations.index'));
+
+        $this->assertSame(ReservationStatus::Cancelled, $reservation->fresh()->status);
+        $this->assertSame(ReservationSlotStatus::Available, $reservation->reservationSlot->fresh()->status);
+    }
+
+    public function test_キャンセル済みの予約を再キャンセルしても冪等に動作する(): void
+    {
+        $reservation = $this->makeConfirmedReservation();
+        $reservation->update(['status' => ReservationStatus::Cancelled]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->delete(route('admin.reservations.cancel', $reservation))
+            ->assertRedirect(route('admin.reservations.index'));
+
+        $this->assertSame(ReservationStatus::Cancelled, $reservation->fresh()->status);
+    }
+
+    // ----------------------------------------------------------------
+    // ヘルパー
+    // ----------------------------------------------------------------
+
+    private function makeConfirmedReservation(): Reservation
+    {
+        $roomType = RoomType::factory()->create();
+        $plan     = AccommodationPlan::factory()->create();
+        $slot     = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'status'       => ReservationSlotStatus::Booked,
+        ]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+
+        return Reservation::factory()->create([
+            'reservation_slot_id'   => $slot->id,
+            'accommodation_plan_id' => $plan->id,
+            'last_name'             => '田中',
+            'status'                => ReservationStatus::Confirmed,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- `Admin/Reservation/IndexController` / `CancelController` に HTTP レベルテスト 6 件を追加
- 未認証チェック（2件）・IndexController（2件）・CancelController（2件）

## Test plan

- [ ] `sail artisan test` → 46 tests passed
- [ ] PHPStan level 6 → No errors

Closes #76