### PR TITLE
feat: 宿泊プラン管理（作成・編集・削除・複数画像・部屋タイプ別料金）#70

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/DestroyController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/DestroyController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Services\AccommodationPlanService;
+use Illuminate\Http\RedirectResponse;
+
+class DestroyController extends Controller
+{
+    public function __invoke(AccommodationPlan $plan, AccommodationPlanService $service): RedirectResponse
+    {
+        $service->destroy($plan);
+
+        return redirect()->route('admin.plans.index');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/EditController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/EditController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Models\RoomType;
+use Illuminate\Contracts\View\View;
+
+class EditController extends Controller
+{
+    public function __invoke(AccommodationPlan $plan): View
+    {
+        $roomTypes = RoomType::orderBy('id')->get();
+
+        return view('admin.plan.edit', compact('plan', 'roomTypes'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/IndexController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Models\RoomType;
+use Illuminate\Contracts\View\View;
+
+class IndexController extends Controller
+{
+    public function __invoke(): View
+    {
+        $plans     = AccommodationPlan::with(['planImages', 'planRoomPrices.roomType'])->paginate(20);
+        $roomTypes = RoomType::orderBy('id')->get();
+
+        return view('admin.plan.index', compact('plans', 'roomTypes'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Services\AccommodationPlanService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class StoreController extends Controller
+{
+    public function __invoke(Request $request, AccommodationPlanService $service): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name'        => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'images'      => ['nullable', 'array'],
+            'images.*'    => ['image'],
+            'prices'      => ['nullable', 'array'],
+            'prices.*'    => ['integer', 'min:0'],
+        ]);
+
+        $service->store(
+            $validated['name'],
+            $validated['description'] ?? null,
+            $validated['images'] ?? [],
+            $validated['prices'] ?? [],
+        );
+
+        return redirect()->route('admin.plans.index');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Services\AccommodationPlanService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class UpdateController extends Controller
+{
+    public function __invoke(Request $request, AccommodationPlan $plan, AccommodationPlanService $service): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name'        => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'images'      => ['nullable', 'array'],
+            'images.*'    => ['image'],
+            'prices'      => ['nullable', 'array'],
+            'prices.*'    => ['integer', 'min:0'],
+        ]);
+
+        $service->update(
+            $plan,
+            $validated['name'],
+            $validated['description'] ?? null,
+            $validated['images'] ?? [],
+            $validated['prices'] ?? [],
+        );
+
+        return redirect()->route('admin.plans.index');
+    }
+}

--- a/hotel-reservation/src/app/Services/AccommodationPlanService.php
+++ b/hotel-reservation/src/app/Services/AccommodationPlanService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AccommodationPlan;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class AccommodationPlanService
+{
+    /**
+     * @param UploadedFile[] $images
+     * @param array<int, int> $prices  [room_type_id => price]
+     */
+    public function store(string $name, ?string $description, array $images, array $prices): AccommodationPlan
+    {
+        $plan = AccommodationPlan::create([
+            'name'        => $name,
+            'description' => $description,
+        ]);
+
+        $this->saveImages($plan, $images);
+        $this->syncPrices($plan, $prices);
+
+        return $plan->load('planImages');
+    }
+
+    /**
+     * @param UploadedFile[] $images
+     * @param array<int, int> $prices
+     */
+    public function update(
+        AccommodationPlan $plan,
+        string $name,
+        ?string $description,
+        array $images,
+        array $prices
+    ): void {
+        $plan->update([
+            'name'        => $name,
+            'description' => $description,
+        ]);
+
+        if (!empty($images)) {
+            $this->deleteImages($plan);
+            $this->saveImages($plan, $images);
+        }
+
+        $this->syncPrices($plan, $prices);
+    }
+
+    public function destroy(AccommodationPlan $plan): void
+    {
+        $this->deleteImages($plan);
+        $plan->delete();
+    }
+
+    /** @param UploadedFile[] $images */
+    private function saveImages(AccommodationPlan $plan, array $images): void
+    {
+        foreach ($images as $image) {
+            $path = $image->store('plan-images', 'public');
+            $plan->planImages()->create([
+                'name'       => $image->getClientOriginalName(),
+                'image_path' => $path,
+            ]);
+        }
+    }
+
+    private function deleteImages(AccommodationPlan $plan): void
+    {
+        foreach ($plan->planImages()->get() as $planImage) {
+            Storage::disk('public')->delete($planImage->image_path);
+        }
+        $plan->planImages()->delete();
+    }
+
+    /** @param array<int, int> $prices */
+    private function syncPrices(AccommodationPlan $plan, array $prices): void
+    {
+        foreach ($prices as $roomTypeId => $price) {
+            $plan->planRoomPrices()->updateOrCreate(
+                ['room_type_id' => $roomTypeId],
+                ['price'        => $price]
+            );
+        }
+    }
+}

--- a/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>宿泊プラン編集</title>
+</head>
+<body>
+<h1>宿泊プラン編集</h1>
+<a href="{{ route('admin.plans.index') }}">← 一覧へ</a>
+
+<form action="{{ route('admin.plans.update', $plan) }}" method="POST" enctype="multipart/form-data">
+    @csrf
+    @method('PUT')
+    <label>プラン名：<input type="text" name="name" value="{{ old('name', $plan->name) }}" required></label>
+    <label>説明：<textarea name="description">{{ old('description', $plan->description) }}</textarea></label>
+    <label>画像（変更する場合のみ）：<input type="file" name="images[]" multiple accept="image/*"></label>
+    @foreach ($roomTypes as $roomType)
+        @php $price = $plan->planRoomPrices->firstWhere('room_type_id', $roomType->id) @endphp
+        <label>{{ $roomType->name }} 料金：
+            <input type="number" name="prices[{{ $roomType->id }}]" min="0"
+                   value="{{ old("prices.{$roomType->id}", $price?->price) }}">
+        </label>
+    @endforeach
+    @if ($errors->any())
+        <ul style="color:red">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+    <button type="submit">更新</button>
+</form>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/admin/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/index.blade.php
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>宿泊プラン管理</title>
+</head>
+<body>
+<h1>宿泊プラン管理</h1>
+<a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
+
+<h2>プラン作成</h2>
+<form action="{{ route('admin.plans.store') }}" method="POST" enctype="multipart/form-data">
+    @csrf
+    <label>プラン名：<input type="text" name="name" value="{{ old('name') }}" required></label>
+    <label>説明：<textarea name="description">{{ old('description') }}</textarea></label>
+    <label>画像：<input type="file" name="images[]" multiple accept="image/*"></label>
+    @foreach ($roomTypes as $roomType)
+        <label>{{ $roomType->name }} 料金：
+            <input type="number" name="prices[{{ $roomType->id }}]" min="0">
+        </label>
+    @endforeach
+    @if ($errors->any())
+        <ul style="color:red">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    @endif
+    <button type="submit">作成</button>
+</form>
+
+<h2>プラン一覧</h2>
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>プラン名</th>
+            <th>操作</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($plans as $plan)
+            <tr>
+                <td>{{ $plan->id }}</td>
+                <td>{{ $plan->name }}</td>
+                <td>
+                    <a href="{{ route('admin.plans.edit', $plan) }}">編集</a>
+                    <form action="{{ route('admin.plans.destroy', $plan) }}" method="POST" style="display:inline">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit">削除</button>
+                    </form>
+                </td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $plans->links() }}
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -2,6 +2,11 @@
 
 use App\Http\Controllers\Admin\Auth\LoginController;
 use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\Plan\DestroyController as AdminPlanDestroyController;
+use App\Http\Controllers\Admin\Plan\EditController as AdminPlanEditController;
+use App\Http\Controllers\Admin\Plan\IndexController as AdminPlanIndexController;
+use App\Http\Controllers\Admin\Plan\StoreController as AdminPlanStoreController;
+use App\Http\Controllers\Admin\Plan\UpdateController as AdminPlanUpdateController;
 use App\Http\Controllers\Admin\Reservation\CancelController as AdminReservationCancelController;
 use App\Http\Controllers\Admin\Reservation\IndexController as AdminReservationIndexController;
 use App\Http\Controllers\Admin\ReservationSlot\BulkStoreController as AdminReservationSlotBulkStoreController;
@@ -44,6 +49,15 @@ Route::prefix('admin')->name('admin.')->group(function () {
         Route::prefix('reservations')->name('reservations.')->group(function () {
             Route::get('/', AdminReservationIndexController::class)->name('index');
             Route::delete('{reservation}/cancel', AdminReservationCancelController::class)->name('cancel');
+        });
+
+        // 宿泊プラン管理
+        Route::prefix('plans')->name('plans.')->group(function () {
+            Route::get('/', AdminPlanIndexController::class)->name('index');
+            Route::post('/', AdminPlanStoreController::class)->name('store');
+            Route::get('{plan}/edit', AdminPlanEditController::class)->name('edit');
+            Route::put('{plan}', AdminPlanUpdateController::class)->name('update');
+            Route::delete('{plan}', AdminPlanDestroyController::class)->name('destroy');
         });
 
         // 予約枠管理

--- a/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature\Admin\Plan;
+
+use App\Models\AccommodationPlan;
+use App\Models\Admin;
+use App\Models\RoomType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PlanControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        $this->admin = Admin::create([
+            'last_name'  => '山田',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+    }
+
+    // ----------------------------------------------------------------
+    // 未認証チェック
+    // ----------------------------------------------------------------
+
+    public function test_未認証ユーザーは一覧にアクセスできない(): void
+    {
+        $this->get(route('admin.plans.index'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーは作成できない(): void
+    {
+        $this->post(route('admin.plans.store'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーは編集フォームにアクセスできない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->get(route('admin.plans.edit', $plan))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーは更新できない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->put(route('admin.plans.update', $plan))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーは削除できない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->delete(route('admin.plans.destroy', $plan))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    // ----------------------------------------------------------------
+    // IndexController
+    // ----------------------------------------------------------------
+
+    public function test_一覧ページが表示される(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk();
+    }
+
+    public function test_プランの一覧が表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => '絶景プラン']);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk()
+            ->assertSee('絶景プラン');
+    }
+
+    // ----------------------------------------------------------------
+    // StoreController
+    // ----------------------------------------------------------------
+
+    public function test_正常な入力でプランを作成できる(): void
+    {
+        $roomType = RoomType::factory()->create();
+
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.plans.store'), [
+                'name'        => '新プラン',
+                'description' => '説明文',
+                'prices'      => [$roomType->id => 12000],
+            ])
+            ->assertRedirect(route('admin.plans.index'));
+
+        $this->assertDatabaseHas('accommodation_plans', ['name' => '新プラン']);
+        $this->assertDatabaseHas('plan_room_prices', [
+            'room_type_id' => $roomType->id,
+            'price'        => 12000,
+        ]);
+    }
+
+    public function test_画像付きでプランを作成できる(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.plans.store'), [
+                'name'   => '画像付きプラン',
+                'images' => [UploadedFile::fake()->image('room.jpg')],
+            ])
+            ->assertRedirect(route('admin.plans.index'));
+
+        $plan = AccommodationPlan::first();
+        $this->assertCount(1, $plan->planImages);
+    }
+
+    public function test_バリデーションエラー時はプランが作成されない(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.plans.store'), [])
+            ->assertSessionHasErrors('name');
+
+        $this->assertDatabaseCount('accommodation_plans', 0);
+    }
+
+    // ----------------------------------------------------------------
+    // EditController
+    // ----------------------------------------------------------------
+
+    public function test_編集フォームが表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.edit', $plan))
+            ->assertOk();
+    }
+
+    // ----------------------------------------------------------------
+    // UpdateController
+    // ----------------------------------------------------------------
+
+    public function test_正常な入力でプランを更新できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => '旧プラン']);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.plans.update', $plan), [
+                'name' => '新プラン',
+            ])
+            ->assertRedirect(route('admin.plans.index'));
+
+        $this->assertDatabaseHas('accommodation_plans', [
+            'id'   => $plan->id,
+            'name' => '新プラン',
+        ]);
+    }
+
+    public function test_バリデーションエラー時はプランが更新されない(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => '元のプラン']);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.plans.update', $plan), ['name' => ''])
+            ->assertSessionHasErrors('name');
+
+        $this->assertDatabaseHas('accommodation_plans', [
+            'id'   => $plan->id,
+            'name' => '元のプラン',
+        ]);
+    }
+
+    // ----------------------------------------------------------------
+    // DestroyController
+    // ----------------------------------------------------------------
+
+    public function test_プランを削除できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->actingAs($this->admin, 'admin')
+            ->delete(route('admin.plans.destroy', $plan))
+            ->assertRedirect(route('admin.plans.index'));
+
+        $this->assertSoftDeleted('accommodation_plans', ['id' => $plan->id]);
+    }
+}

--- a/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Feature\Services;
+
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\RoomType;
+use App\Services\AccommodationPlanService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AccommodationPlanServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AccommodationPlanService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        $this->service = new AccommodationPlanService();
+    }
+
+    public function test_プランを作成できる(): void
+    {
+        $plan = $this->service->store('スタンダードプラン', '快適なお部屋です。', [], []);
+
+        $this->assertInstanceOf(AccommodationPlan::class, $plan);
+        $this->assertDatabaseHas('accommodation_plans', [
+            'name'        => 'スタンダードプラン',
+            'description' => '快適なお部屋です。',
+        ]);
+    }
+
+    public function test_プラン作成時に画像を保存できる(): void
+    {
+        $images = [
+            UploadedFile::fake()->image('room1.jpg'),
+            UploadedFile::fake()->image('room2.jpg'),
+        ];
+
+        $plan = $this->service->store('プランA', null, $images, []);
+
+        $this->assertCount(2, $plan->planImages);
+        Storage::disk('public')->assertExists($plan->planImages[0]->image_path);
+        Storage::disk('public')->assertExists($plan->planImages[1]->image_path);
+    }
+
+    public function test_プラン作成時に部屋タイプ別料金を設定できる(): void
+    {
+        $roomType1 = RoomType::factory()->create();
+        $roomType2 = RoomType::factory()->create();
+
+        $prices = [
+            $roomType1->id => 10000,
+            $roomType2->id => 20000,
+        ];
+
+        $plan = $this->service->store('プランB', null, [], $prices);
+
+        $this->assertDatabaseHas('plan_room_prices', [
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType1->id,
+            'price'                 => 10000,
+        ]);
+        $this->assertDatabaseHas('plan_room_prices', [
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType2->id,
+            'price'                 => 20000,
+        ]);
+    }
+
+    public function test_プランを編集できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => '旧プラン名']);
+
+        $this->service->update($plan, '新プラン名', '新しい説明', [], []);
+
+        $this->assertDatabaseHas('accommodation_plans', [
+            'id'   => $plan->id,
+            'name' => '新プラン名',
+        ]);
+    }
+
+    public function test_編集時に新しい画像を指定すると既存画像が置き換えられる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $oldImage = UploadedFile::fake()->image('old.jpg');
+        $this->service->store($plan->name, null, [$oldImage], []);
+        // 既存画像を直接付与
+        $plan->planImages()->create([
+            'name'       => 'old.jpg',
+            'image_path' => 'plan-images/old.jpg',
+        ]);
+
+        $newImage = UploadedFile::fake()->image('new.jpg');
+        $this->service->update($plan, $plan->name, null, [$newImage], []);
+
+        $this->assertCount(1, $plan->fresh()->planImages);
+        $this->assertSame('new.jpg', $plan->fresh()->planImages->first()->name);
+    }
+
+    public function test_編集時に画像を指定しない場合は既存画像が保持される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $plan->planImages()->create([
+            'name'       => 'existing.jpg',
+            'image_path' => 'plan-images/existing.jpg',
+        ]);
+
+        $this->service->update($plan, $plan->name, null, [], []);
+
+        $this->assertCount(1, $plan->fresh()->planImages);
+    }
+
+    public function test_編集時に料金を更新できる(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+            'price'                 => 10000,
+        ]);
+
+        $this->service->update($plan, $plan->name, null, [], [$roomType->id => 15000]);
+
+        $this->assertDatabaseHas('plan_room_prices', [
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+            'price'                 => 15000,
+        ]);
+    }
+
+    public function test_プランを削除できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->service->destroy($plan);
+
+        $this->assertSoftDeleted('accommodation_plans', ['id' => $plan->id]);
+    }
+
+    public function test_削除済みプランはデフォルトクエリに含まれない(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $this->service->destroy($plan);
+
+        $this->assertNull(AccommodationPlan::find($plan->id));
+    }
+
+    public function test_削除時に画像ファイルも削除される(): void
+    {
+        $plan  = AccommodationPlan::factory()->create();
+        $image = UploadedFile::fake()->image('to-delete.jpg');
+        $this->service->update($plan, $plan->name, null, [$image], []);
+        $imagePath = $plan->fresh()->planImages->first()->image_path;
+        Storage::disk('public')->assertExists($imagePath);
+
+        $this->service->destroy($plan);
+
+        Storage::disk('public')->assertMissing($imagePath);
+    }
+}


### PR DESCRIPTION
## 概要

Issue #70 の宿泊プラン管理機能を TDD で実装。

## 実装内容

- `AccommodationPlanService` — プランの作成・編集・削除ビジネスロジック
- `Admin/Plan/` コントローラー（Index / Store / Edit / Update / Destroy）
- ルート `admin.plans.*`
- View（一覧・編集フォーム）

## テスト

- `AccommodationPlanServiceTest` — 10件（画像保存・料金同期・ソフトデリート・ファイル削除など）
- `PlanControllerTest` — 14件（未認証チェック・CRUD・バリデーション）

## 動作確認

ブラウザで以下を確認済み：
- プラン名のみ・画像付き・料金設定ありの各パターンで作成
- バリデーションエラー時にエラー表示

## 残課題（別 Issue で対応）

- フォームの必須マーク表示
- バリデーションメッセージの日本語カスタマイズ
- 管理画面での登録画像プレビュー