### PR TITLE
fix: 料金フィールドを空欄で送信するとバリデーションエラーになるのを修正

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
@@ -17,14 +17,19 @@ class StoreController extends Controller
             'images'      => ['nullable', 'array'],
             'images.*'    => ['image'],
             'prices'      => ['nullable', 'array'],
-            'prices.*'    => ['integer', 'min:0'],
+            'prices.*'    => ['nullable', 'integer', 'min:0'],
         ]);
+
+        $prices = array_filter(
+            $validated['prices'] ?? [],
+            fn ($v) => $v !== null && $v !== '',
+        );
 
         $service->store(
             $validated['name'],
             $validated['description'] ?? null,
             $validated['images'] ?? [],
-            $validated['prices'] ?? [],
+            $prices,
         );
 
         return redirect()->route('admin.plans.index');

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
@@ -18,15 +18,20 @@ class UpdateController extends Controller
             'images'      => ['nullable', 'array'],
             'images.*'    => ['image'],
             'prices'      => ['nullable', 'array'],
-            'prices.*'    => ['integer', 'min:0'],
+            'prices.*'    => ['nullable', 'integer', 'min:0'],
         ]);
+
+        $prices = array_filter(
+            $validated['prices'] ?? [],
+            fn ($v) => $v !== null && $v !== '',
+        );
 
         $service->update(
             $plan,
             $validated['name'],
             $validated['description'] ?? null,
             $validated['images'] ?? [],
-            $validated['prices'] ?? [],
+            $prices,
         );
 
         return redirect()->route('admin.plans.index');


### PR DESCRIPTION
## 概要

#70 の動作確認で発覚したバグの修正。PR #82 マージ前に push できていなかった fix コミットを改めて適用。

## 問題

プラン作成・編集フォームで料金フィールドを空欄のまま送信すると、`prices.* must be an integer` エラーが発生する。

## 原因

`prices.*` に `nullable` がなく、空文字列が `integer` バリデーションに引っかかっていた。

## 修正

- `prices.*` に `nullable` を追加
- 空文字・null をサービスに渡す前に `array_filter` で除外