### PR TITLE
feat: 宿泊者向けプラン一覧・詳細ページ #86

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/User/Plan/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Plan/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\User\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use Illuminate\Contracts\View\View;
+
+class IndexController extends Controller
+{
+    public function __invoke(): View
+    {
+        $plans = AccommodationPlan::with('planImages')->paginate(12);
+
+        return view('user.plan.index', compact('plans'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Plan/ShowController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Plan/ShowController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\User\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use Illuminate\Contracts\View\View;
+
+class ShowController extends Controller
+{
+    public function __invoke(AccommodationPlan $plan): View
+    {
+        $plan->load(['planImages', 'planRoomPrices.roomType']);
+
+        return view('user.plan.show', compact('plan'));
+    }
+}

--- a/hotel-reservation/src/resources/views/user/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/index.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>宿泊プラン一覧</title>
+</head>
+<body>
+<h1>宿泊プラン一覧</h1>
+
+@forelse ($plans as $plan)
+    <div>
+        <h2>{{ $plan->name }}</h2>
+        @if ($plan->description)
+            <p>{{ $plan->description }}</p>
+        @endif
+        <a href="{{ route('user.plans.show', $plan) }}">詳細を見る</a>
+    </div>
+@empty
+    <p>現在公開中のプランはありません。</p>
+@endforelse
+
+{{ $plans->links() }}
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/plan/show.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/show.blade.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $plan->name }}</title>
+</head>
+<body>
+<a href="{{ route('user.plans.index') }}">← プラン一覧へ</a>
+
+<h1>{{ $plan->name }}</h1>
+
+@if ($plan->planImages->isNotEmpty())
+    <div>
+        @foreach ($plan->planImages as $image)
+            <img src="{{ Storage::url($image->image_path) }}" alt="{{ $image->name }}">
+        @endforeach
+    </div>
+@endif
+
+@if ($plan->description)
+    <p>{{ $plan->description }}</p>
+@endif
+
+@if ($plan->planRoomPrices->isNotEmpty())
+    <h2>料金</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>部屋タイプ</th>
+                <th>1泊料金</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($plan->planRoomPrices as $price)
+                <tr>
+                    <td>{{ $price->roomType->name }}</td>
+                    <td>{{ number_format($price->price) }}円</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endif
+
+{{-- #71 空室カレンダー実装後にリンクを接続する --}}
+<p>空室カレンダーは準備中です。</p>
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -15,6 +15,8 @@ use App\Http\Controllers\Admin\ReservationSlot\EditController as AdminReservatio
 use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservationSlotIndexController;
 use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
 use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
+use App\Http\Controllers\User\Plan\IndexController as UserPlanIndexController;
+use App\Http\Controllers\User\Plan\ShowController as UserPlanShowController;
 use App\Http\Controllers\User\Reservation\ConfirmController as UserReservationConfirmController;
 use App\Http\Controllers\User\Reservation\CreateController as UserReservationCreateController;
 use App\Http\Controllers\User\Reservation\StoreController as UserReservationStoreController;
@@ -22,6 +24,12 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+// 宿泊者：プラン閲覧（認証不要）
+Route::prefix('plans')->name('user.plans.')->group(function () {
+    Route::get('/', UserPlanIndexController::class)->name('index');
+    Route::get('{plan}', UserPlanShowController::class)->name('show');
 });
 
 // 宿泊者：予約フロー（認証不要）

--- a/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\User\Plan;
+
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\RoomType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlanControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ----------------------------------------------------------------
+    // IndexController
+    // ----------------------------------------------------------------
+
+    public function test_プラン一覧ページが表示される(): void
+    {
+        $this->get(route('user.plans.index'))
+            ->assertOk();
+    }
+
+    public function test_プランの一覧が表示される(): void
+    {
+        AccommodationPlan::factory()->create(['name' => '絶景プラン']);
+
+        $this->get(route('user.plans.index'))
+            ->assertOk()
+            ->assertSee('絶景プラン');
+    }
+
+    public function test_削除済みのプランは一覧に表示されない(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => '削除済みプラン']);
+        $plan->delete();
+
+        $this->get(route('user.plans.index'))
+            ->assertOk()
+            ->assertDontSee('削除済みプラン');
+    }
+
+    // ----------------------------------------------------------------
+    // ShowController
+    // ----------------------------------------------------------------
+
+    public function test_プラン詳細ページが表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create(['name' => 'スタンダードプラン']);
+
+        $this->get(route('user.plans.show', $plan))
+            ->assertOk()
+            ->assertSee('スタンダードプラン');
+    }
+
+    public function test_プラン詳細ページに料金が表示される(): void
+    {
+        $roomType = RoomType::factory()->create(['name' => 'デラックスルーム']);
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+            'price'                 => 15000,
+        ]);
+
+        $this->get(route('user.plans.show', $plan))
+            ->assertOk()
+            ->assertSee('デラックスルーム')
+            ->assertSee('15,000');
+    }
+
+    public function test_削除済みのプランの詳細は404になる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $plan->delete();
+
+        $this->get(route('user.plans.show', $plan))
+            ->assertNotFound();
+    }
+}


### PR DESCRIPTION
## 概要

Issue #86。宿泊者が予約フローへたどり着くための入口となるプラン閲覧ページを実装。

## 実装内容

- `GET /plans` — プラン一覧（`user.plans.index`）
- `GET /plans/{plan}` — プラン詳細・料金表示（`user.plans.show`）
- 削除済みプランは一覧非表示・詳細 404

## テスト

`User/Plan/PlanControllerTest` — 6件
- 一覧表示・プラン名表示・削除済み非表示
- 詳細表示・料金表示・削除済み404

## 次のステップ

#71（空室カレンダー）実装後、詳細ページのカレンダーリンクを接続する。