### PR TITLE
feat: 空室カレンダー（○/× 表示・予約フォームへの接続）を実装（Issue #71）

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/User/Plan/CalendarController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Plan/CalendarController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\User\Plan;
+
+use App\Http\Controllers\Controller;
+use App\Models\AccommodationPlan;
+use App\Services\CalendarService;
+use Carbon\Carbon;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class CalendarController extends Controller
+{
+    public function __invoke(Request $request, AccommodationPlan $plan, CalendarService $service): View
+    {
+        $year  = $request->integer('year', (int) now()->format('Y'));
+        $month = $request->integer('month', (int) now()->format('n'));
+
+        $calendar  = $service->getMonthlyAvailability($plan, $year, $month);
+        $firstDay  = Carbon::create($year, $month, 1);
+
+        return view('user.plan.calendar', compact('plan', 'calendar', 'firstDay'));
+    }
+}

--- a/hotel-reservation/src/app/Services/CalendarService.php
+++ b/hotel-reservation/src/app/Services/CalendarService.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\AccommodationPlan;
+use App\Models\ReservationSlot;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+
+class CalendarService
+{
+    /**
+     * プランの月次空室状況を返す。
+     *
+     * @return array<string, array{available: bool, slot_id: int|null}>
+     *         キーは 'Y-m-d' 形式の日付文字列
+     */
+    public function getMonthlyAvailability(AccommodationPlan $plan, int $year, int $month): array
+    {
+        $roomTypeIds = $plan->planRoomPrices()->pluck('room_type_id')->all();
+
+        $firstDay = Carbon::create($year, $month, 1);
+        $lastDay  = $firstDay->copy()->endOfMonth();
+
+        $slots = ReservationSlot::whereIn('room_type_id', $roomTypeIds)
+            ->whereBetween('start', [$firstDay->toDateString(), $lastDay->toDateString()])
+            ->get()
+            ->groupBy(fn ($slot) => $slot->start->toDateString());
+
+        $calendar = [];
+        foreach (CarbonPeriod::create($firstDay, $lastDay) as $day) {
+            $dateKey     = $day->toDateString();
+            $daySlots    = $slots->get($dateKey, collect());
+            $available   = $daySlots->contains('status', ReservationSlotStatus::Available);
+            $availSlot   = $available
+                ? $daySlots->first(fn ($s) => $s->status === ReservationSlotStatus::Available)
+                : null;
+
+            $calendar[$dateKey] = [
+                'available' => $available,
+                'slot_id'   => $availSlot?->id,
+            ];
+        }
+
+        return $calendar;
+    }
+}

--- a/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>空室カレンダー - {{ $plan->name }}</title>
+</head>
+<body>
+<a href="{{ route('user.plans.show', $plan) }}">← プラン詳細へ</a>
+
+<h1>{{ $plan->name }} — 空室カレンダー</h1>
+<h2>{{ $firstDay->format('Y年n月') }}</h2>
+
+<table border="1">
+    <thead>
+        <tr>
+            <th>日</th>
+            <th>月</th>
+            <th>火</th>
+            <th>水</th>
+            <th>木</th>
+            <th>金</th>
+            <th>土</th>
+        </tr>
+    </thead>
+    <tbody>
+        @php
+            $startDow = $firstDay->dayOfWeek; // 0=Sun
+            $cellIndex = 0;
+        @endphp
+        <tr>
+            @for ($i = 0; $i < $startDow; $i++)
+                <td></td>
+                @php $cellIndex++ @endphp
+            @endfor
+
+            @foreach ($calendar as $date => $info)
+                @if ($cellIndex > 0 && $cellIndex % 7 === 0)
+                    </tr><tr>
+                @endif
+                <td>
+                    {{ \Carbon\Carbon::parse($date)->day }}日<br>
+                    @if ($info['available'])
+                        <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}">○</a>
+                    @else
+                        ×
+                    @endif
+                </td>
+                @php $cellIndex++ @endphp
+            @endforeach
+        </tr>
+    </tbody>
+</table>
+
+<div>
+    @php
+        $prevMonth = $firstDay->copy()->subMonth();
+        $nextMonth = $firstDay->copy()->addMonth();
+    @endphp
+    <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $prevMonth->year, 'month' => $prevMonth->month]) }}">← 前月</a>
+    &nbsp;
+    <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month]) }}">翌月 →</a>
+</div>
+</body>
+</html>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\Admin\ReservationSlot\EditController as AdminReservatio
 use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservationSlotIndexController;
 use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
 use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
+use App\Http\Controllers\User\Plan\CalendarController as UserPlanCalendarController;
 use App\Http\Controllers\User\Plan\IndexController as UserPlanIndexController;
 use App\Http\Controllers\User\Plan\ShowController as UserPlanShowController;
 use App\Http\Controllers\User\Reservation\ConfirmController as UserReservationConfirmController;
@@ -30,6 +31,7 @@ Route::get('/', function () {
 Route::prefix('plans')->name('user.plans.')->group(function () {
     Route::get('/', UserPlanIndexController::class)->name('index');
     Route::get('{plan}', UserPlanShowController::class)->name('show');
+    Route::get('{plan}/calendar', UserPlanCalendarController::class)->name('calendar');
 });
 
 // 宿泊者：予約フロー（認証不要）

--- a/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\User\Plan;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CalendarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_カレンダーページが表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->get(route('user.plans.calendar', $plan))
+            ->assertOk();
+    }
+
+    public function test_削除済みプランは404になる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $plan->delete();
+
+        $this->get(route('user.plans.calendar', $plan))
+            ->assertNotFound();
+    }
+
+    public function test_空きのある日付に○が表示される(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('○');
+    }
+
+    public function test_スロットがない日付に×が表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('×');
+    }
+
+    public function test_予約済みスロットしかない日付に×が表示される(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Booked,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('×');
+    }
+
+    public function test_プランに料金設定のない部屋タイプのスロットは○にならない(): void
+    {
+        $roomType        = RoomType::factory()->create();
+        $otherRoomType   = RoomType::factory()->create();
+        $plan            = AccommodationPlan::factory()->create();
+        // plan には $otherRoomType の料金のみ設定
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $otherRoomType->id,
+        ]);
+        // スロットは $roomType（料金設定なし）
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('×');
+    }
+
+    public function test_○の日付に予約フォームへのリンクがある(): void
+    {
+        $roomType = RoomType::factory()->create();
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee(route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]));
+    }
+}


### PR DESCRIPTION
## Summary

- `CalendarService::getMonthlyAvailability()` を実装し、プランに紐づく部屋タイプの予約枠を月次で集計
- `CalendarController` を実装し、`GET /plans/{plan}/calendar?year=Y&month=M` でカレンダーページを返す
- `resources/views/user/plan/calendar.blade.php` で○/× 表示・予約フォームへのリンク・前後月ナビゲーションを実装
- `CalendarControllerTest` で 7 件のテストを追加（削除済みプラン 404・空き○・満室×・料金未設定の部屋タイプ除外など）

Closes #71

## Test plan

- [x] `./vendor/bin/sail artisan test --filter=CalendarControllerTest` — 7 件全通過
- [x] 全テスト 90 件パス