### PR TITLE
feat: 空室カレンダーに△（残りわずか）表示を追加（Issue #72）

### DIFF
--- a/hotel-reservation/src/app/Enums/CalendarAvailability.php
+++ b/hotel-reservation/src/app/Enums/CalendarAvailability.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum CalendarAvailability
+{
+    case Available;   // 空きあり（2枠以上）
+    case Limited;     // 残りわずか（1枠）
+    case Unavailable; // 空きなし
+}

--- a/hotel-reservation/src/app/Services/CalendarService.php
+++ b/hotel-reservation/src/app/Services/CalendarService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\CalendarAvailability;
 use App\Enums\ReservationSlotStatus;
 use App\Models\AccommodationPlan;
 use App\Models\ReservationSlot;
@@ -13,7 +14,7 @@ class CalendarService
     /**
      * プランの月次空室状況を返す。
      *
-     * @return array<string, array{available: bool, slot_id: int|null}>
+     * @return array<string, array{availability: CalendarAvailability, slot_id: int|null}>
      *         キーは 'Y-m-d' 形式の日付文字列
      */
     public function getMonthlyAvailability(AccommodationPlan $plan, int $year, int $month): array
@@ -30,16 +31,20 @@ class CalendarService
 
         $calendar = [];
         foreach (CarbonPeriod::create($firstDay, $lastDay) as $day) {
-            $dateKey     = $day->toDateString();
-            $daySlots    = $slots->get($dateKey, collect());
-            $available   = $daySlots->contains('status', ReservationSlotStatus::Available);
-            $availSlot   = $available
-                ? $daySlots->first(fn ($s) => $s->status === ReservationSlotStatus::Available)
-                : null;
+            $dateKey    = $day->toDateString();
+            $daySlots   = $slots->get($dateKey, collect());
+            $availSlots = $daySlots->filter(fn ($s) => $s->status === ReservationSlotStatus::Available);
+            $availCount = $availSlots->count();
+
+            $availability = match (true) {
+                $availCount >= 2 => CalendarAvailability::Available,
+                $availCount === 1 => CalendarAvailability::Limited,
+                default          => CalendarAvailability::Unavailable,
+            };
 
             $calendar[$dateKey] = [
-                'available' => $available,
-                'slot_id'   => $availSlot?->id,
+                'availability' => $availability,
+                'slot_id'      => $availCount >= 1 ? $availSlots->first()->id : null,
             ];
         }
 

--- a/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
@@ -39,8 +39,10 @@
                 @endif
                 <td>
                     {{ \Carbon\Carbon::parse($date)->day }}日<br>
-                    @if ($info['available'])
+                    @if ($info['availability'] === \App\Enums\CalendarAvailability::Available)
                         <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}">○</a>
+                    @elseif ($info['availability'] === \App\Enums\CalendarAvailability::Limited)
+                        <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}">△</a>
                     @else
                         ×
                     @endif

--- a/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
@@ -31,7 +31,38 @@ class CalendarControllerTest extends TestCase
             ->assertNotFound();
     }
 
-    public function test_空きのある日付に○が表示される(): void
+    public function test_空きが2つ以上の日付に○が表示される(): void
+    {
+        $roomType1 = RoomType::factory()->create();
+        $roomType2 = RoomType::factory()->create();
+        $plan      = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType1->id,
+        ]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType2->id,
+        ]);
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType1->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType2->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('○');
+    }
+
+    public function test_空きが1つの日付に△が表示される(): void
     {
         $roomType = RoomType::factory()->create();
         $plan     = AccommodationPlan::factory()->create();
@@ -48,7 +79,7 @@ class CalendarControllerTest extends TestCase
 
         $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
             ->assertOk()
-            ->assertSee('○');
+            ->assertSee('△');
     }
 
     public function test_スロットがない日付に×が表示される(): void
@@ -82,9 +113,9 @@ class CalendarControllerTest extends TestCase
 
     public function test_プランに料金設定のない部屋タイプのスロットは○にならない(): void
     {
-        $roomType        = RoomType::factory()->create();
-        $otherRoomType   = RoomType::factory()->create();
-        $plan            = AccommodationPlan::factory()->create();
+        $roomType      = RoomType::factory()->create();
+        $otherRoomType = RoomType::factory()->create();
+        $plan          = AccommodationPlan::factory()->create();
         // plan には $otherRoomType の料金のみ設定
         PlanRoomPrice::factory()->create([
             'accommodation_plan_id' => $plan->id,
@@ -104,6 +135,37 @@ class CalendarControllerTest extends TestCase
     }
 
     public function test_○の日付に予約フォームへのリンクがある(): void
+    {
+        $roomType1 = RoomType::factory()->create();
+        $roomType2 = RoomType::factory()->create();
+        $plan      = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType1->id,
+        ]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType2->id,
+        ]);
+        $slot = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType1->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+        ReservationSlot::factory()->create([
+            'room_type_id' => $roomType2->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee(route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]));
+    }
+
+    public function test_△の日付に予約フォームへのリンクがある(): void
     {
         $roomType = RoomType::factory()->create();
         $plan     = AccommodationPlan::factory()->create();


### PR DESCRIPTION
## Summary

- `CalendarAvailability` Enum を新設（`Available` / `Limited` / `Unavailable`）
- `CalendarService` を更新し、Available 枠数で3状態を判定
  - 2枠以上 → `Available`（○）
  - 1枠 → `Limited`（△）
  - 0枠 → `Unavailable`（×）
- カレンダービューに △ 表示を追加（△ も予約フォームへのリンクあり）
- テストを 7件 → 9件に拡充

Closes #72

## Test plan

- [x] 全テスト 92 件パス
- [x] 1枠の日付 → △ 表示・予約フォームへのリンクあり
- [x] 2枠以上の日付 → ○ 表示
- [x] ブラウザで動作確認（○/△/× の切り替えを確認）