### PR TITLE
feat: 共通レイアウト作成と全ビューを@extendsに移行（Issue #92）

### DIFF
--- a/hotel-reservation/src/resources/views/admin/auth/login.blade.php
+++ b/hotel-reservation/src/resources/views/admin/auth/login.blade.php
@@ -1,33 +1,28 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>管理者ログイン</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
-    <h1>管理者ログイン</h1>
+@extends('layouts.admin')
 
-    @if ($errors->any())
-        <ul>
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    @endif
+@section('title', '管理者ログイン')
 
-    <form method="POST" action="{{ route('admin.login.store') }}" novalidate>
-        @csrf
-        <div>
-            <label for="email">メールアドレス</label>
-            <input type="email" id="email" name="email" value="{{ old('email') }}" required>
-        </div>
-        <div>
-            <label for="password">パスワード</label>
-            <input type="password" id="password" name="password" required>
-        </div>
-        <button type="submit">ログイン</button>
-    </form>
-</body>
-</html>
+@section('content')
+<h1>管理者ログイン</h1>
+
+@if ($errors->any())
+    <ul>
+        @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif
+
+<form method="POST" action="{{ route('admin.login.store') }}" novalidate>
+    @csrf
+    <div>
+        <label for="email">メールアドレス</label>
+        <input type="email" id="email" name="email" value="{{ old('email') }}" required>
+    </div>
+    <div>
+        <label for="password">パスワード</label>
+        <input type="password" id="password" name="password" required>
+    </div>
+    <button type="submit">ログイン</button>
+</form>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/dashboard.blade.php
+++ b/hotel-reservation/src/resources/views/admin/dashboard.blade.php
@@ -1,18 +1,13 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>管理者ダッシュボード</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
-    <h1>管理者ダッシュボード</h1>
-    <p>ログイン中: {{ Auth::guard('admin')->user()->last_name }} {{ Auth::guard('admin')->user()->first_name }}</p>
-    <form method="POST" action="{{ route('admin.logout') }}">
-        @csrf
-        @method('DELETE')
-        <button type="submit">ログアウト</button>
-    </form>
-</body>
-</html>
+@extends('layouts.admin')
+
+@section('title', 'ダッシュボード')
+
+@section('content')
+<h1>管理者ダッシュボード</h1>
+<p>ログイン中: {{ Auth::guard('admin')->user()->last_name }} {{ Auth::guard('admin')->user()->first_name }}</p>
+<form method="POST" action="{{ route('admin.logout') }}">
+    @csrf
+    @method('DELETE')
+    <button type="submit">ログアウト</button>
+</form>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>宿泊プラン編集</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.admin')
+
+@section('title', '宿泊プラン編集')
+
+@section('content')
 <h1>宿泊プラン編集</h1>
 <a href="{{ route('admin.plans.index') }}">← 一覧へ</a>
 
@@ -31,5 +28,4 @@
     @endif
     <button type="submit">更新</button>
 </form>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/index.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>宿泊プラン管理</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.admin')
+
+@section('title', '宿泊プラン管理')
+
+@section('content')
 <h1>宿泊プラン管理</h1>
 <a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
 
@@ -57,5 +54,4 @@
     </tbody>
 </table>
 {{ $plans->links() }}
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約枠編集</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.admin')
+
+@section('title', '予約枠編集')
+
+@section('content')
 <h1>予約枠編集</h1>
 <a href="{{ route('admin.reservation-slots.index') }}">← 一覧へ戻る</a>
 
@@ -51,5 +48,4 @@
 
     <button type="submit">更新</button>
 </form>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約枠管理</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.admin')
+
+@section('title', '予約枠管理')
+
+@section('content')
 <h1>予約枠管理</h1>
 <a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
 
@@ -101,5 +98,4 @@
 </table>
 
 {{ $slots->links() }}
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約一覧（管理者）</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.admin')
+
+@section('title', '予約一覧')
+
+@section('content')
 <h1>予約一覧</h1>
 
 @if (session('success'))
@@ -58,5 +55,4 @@
 {{ $reservations->links() }}
 
 <p><a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a></p>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/layouts/admin.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin.blade.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', '管理画面') | {{ config('app.name') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body>
+    @auth('admin')
+    <nav class="navbar navbar-expand-lg bg-dark navbar-dark shadow-sm">
+        <div class="container">
+            <a class="navbar-brand" href="{{ route('admin.dashboard') }}">管理画面</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="メニューを開く">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="adminNav">
+                <ul class="navbar-nav me-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.plans.index') }}">プラン管理</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.reservation-slots.index') }}">予約枠管理</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('admin.reservations.index') }}">予約管理</a>
+                    </li>
+                </ul>
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <form method="POST" action="{{ route('admin.logout') }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-outline-light btn-sm">ログアウト</button>
+                        </form>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    @endauth
+
+    <main>
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/layouts/app.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/app.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', config('app.name'))</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg bg-white shadow-sm">
+        <div class="container">
+            <a class="navbar-brand fw-semibold" href="{{ url('/') }}">{{ config('app.name') }}</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarMain" aria-controls="navbarMain" aria-expanded="false" aria-label="メニューを開く">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarMain">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url('/') }}">TOP</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('user.plans.index') }}">宿泊プラン</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">客室紹介</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">アクセス案内</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="#">お問い合わせ</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        @yield('content')
+    </main>
+
+    <footer class="bg-white border-top py-4 mt-5">
+        <div class="container text-center">
+            <p class="mb-1 fw-semibold">{{ config('app.name') }}</p>
+            <p class="text-muted small mb-0">&copy; {{ date('Y') }} {{ config('app.name') }}. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>空室カレンダー - {{ $plan->name }}</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title')空室カレンダー - {{ $plan->name }}@endsection
+
+@section('content')
 <a href="{{ route('user.plans.show', $plan) }}">← プラン詳細へ</a>
 
 <h1>{{ $plan->name }} — 空室カレンダー</h1>
@@ -63,5 +60,4 @@
     &nbsp;
     <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month]) }}">翌月 →</a>
 </div>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/user/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/index.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>宿泊プラン一覧</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title', '宿泊プラン一覧')
+
+@section('content')
 <h1>宿泊プラン一覧</h1>
 
 @forelse ($plans as $plan)
@@ -21,5 +18,4 @@
 @endforelse
 
 {{ $plans->links() }}
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/user/plan/show.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/show.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>{{ $plan->name }}</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title'){{ $plan->name }}@endsection
+
+@section('content')
 <a href="{{ route('user.plans.index') }}">← プラン一覧へ</a>
 
 <h1>{{ $plan->name }}</h1>
@@ -44,5 +41,4 @@
 
 {{-- #71 空室カレンダー実装後にリンクを接続する --}}
 <p>空室カレンダーは準備中です。</p>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
@@ -1,13 +1,9 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約完了</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title', '予約完了')
+
+@section('content')
 <h1>予約が完了しました</h1>
 <p>ご予約ありがとうございます。確認メールをお送りします。</p>
 <a href="/">TOPページへ</a>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約内容確認</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title', '予約内容確認')
+
+@section('content')
 <h1>予約内容確認</h1>
 <p>以下の内容で予約を確定します。よろしければ「予約を確定する」ボタンを押してください。</p>
 
@@ -29,5 +26,4 @@
 </form>
 
 <a href="{{ route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]) }}">← 入力に戻る</a>
-</body>
-</html>
+@endsection

--- a/hotel-reservation/src/resources/views/user/reservation/create.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/create.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約フォーム</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-</head>
-<body>
+@extends('layouts.app')
+
+@section('title', '予約フォーム')
+
+@section('content')
 <h1>予約フォーム</h1>
 
 <table border="1">
@@ -38,5 +35,4 @@
 
     <button type="submit">確認画面へ</button>
 </form>
-</body>
-</html>
+@endsection


### PR DESCRIPTION
## Summary

- `layouts/app.blade.php`（宿泊者向け）を新規作成
  - 星野リゾートインスパイア：白基調・shadow-sm Navbar・ハンバーガーメニュー対応
  - フッター（ホテル名・コピーライト）
  - 未実装ページ（客室紹介・アクセス案内・お問い合わせ）は `#` でプレースホルダー
- `layouts/admin.blade.php`（管理者向け）を新規作成
  - ダークナビ（プラン管理・予約枠管理・予約管理・ログアウト）
  - `@auth('admin')` で認証時のみナビ表示（ログインページでは非表示）
- 宿泊者向けビュー 6 本・管理者向けビュー 7 本を `@extends` 構造に移行
  （コンテンツのデザイン作り込みは各ページ Issue で実施）

## Test plan

- [x] 全 92 件テスト Pass
- [x] ブラウザで宿泊者ナビ・管理者ナビの表示を確認
- [x] スマホ幅でハンバーガーメニューの動作確認

`APP_NAME` を `.env` でホテル名に変更すると navbar/footer のロゴ表記が変わる。

Closes #92