### PR TITLE
fix: プラン詳細→空室カレンダーのリンクを接続 (#118)

### DIFF
--- a/hotel-reservation/src/resources/views/user/plan/show.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/show.blade.php
@@ -39,6 +39,5 @@
     </table>
 @endif
 
-{{-- #71 空室カレンダー実装後にリンクを接続する --}}
-<p>空室カレンダーは準備中です。</p>
+<a href="{{ route('user.plans.calendar', $plan) }}">空室カレンダーを確認する</a>
 @endsection

--- a/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
@@ -70,6 +70,15 @@ class PlanControllerTest extends TestCase
             ->assertSee('15,000');
     }
 
+    public function test_プラン詳細ページに空室カレンダーへのリンクがある(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->get(route('user.plans.show', $plan))
+            ->assertOk()
+            ->assertSee(route('user.plans.calendar', $plan));
+    }
+
     public function test_削除済みのプランの詳細は404になる(): void
     {
         $plan = AccommodationPlan::factory()->create();


### PR DESCRIPTION
## Summary

- `user/plan/show.blade.php` の「空室カレンダーは準備中です。」プレースホルダーを削除
- `route('user.plans.calendar', $plan)` へのリンクに差し替え
- プラン詳細→空室カレンダー→予約フォームの導線が完全に繋がった

## Test

- `test_プラン詳細ページに空室カレンダーへのリンクがある` を追加

## Related

Closes #118