### PR TITLE
feat: 宿泊プラン一覧・詳細ページの UI 改善（Bootstrap）(#119)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/User/Plan/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Plan/IndexController.php
@@ -10,7 +10,7 @@ class IndexController extends Controller
 {
     public function __invoke(): View
     {
-        $plans = AccommodationPlan::with('planImages')->paginate(12);
+        $plans = AccommodationPlan::with(['planImages', 'planRoomPrices'])->paginate(12);
 
         return view('user.plan.index', compact('plans'));
     }

--- a/hotel-reservation/src/database/seeders/AccommodationPlanSeeder.php
+++ b/hotel-reservation/src/database/seeders/AccommodationPlanSeeder.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AccommodationPlan;
+use App\Models\PlanRoomPrice;
+use App\Models\RoomType;
+use Illuminate\Database\Seeder;
+
+class AccommodationPlanSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $standard = RoomType::where('name', 'スタンダードルーム')->first();
+        $deluxe   = RoomType::where('name', 'デラックスルーム')->first();
+        $suite    = RoomType::where('name', 'スイートルーム')->first();
+
+        $plans = [
+            [
+                'plan' => [
+                    'name'        => '【朝食付き】森の恵みスタンダードプラン',
+                    'description' => '旬の野菜を使った和朝食をご用意するシンプルな宿泊プランです。山の清涼な空気の中でゆっくりとした朝をお過ごしください。',
+                ],
+                'prices' => [
+                    [$standard, 12000],
+                    [$deluxe,   18000],
+                    [$suite,    35000],
+                ],
+            ],
+            [
+                'plan' => [
+                    'name'        => '【2食付き】山の幸グルメプラン',
+                    'description' => '地元の山の幸をふんだんに使った会席料理をご堪能いただけます。夕食・朝食ともにシェフ自慢の一品をご提供します。',
+                ],
+                'prices' => [
+                    [$standard, 22000],
+                    [$deluxe,   30000],
+                    [$suite,    55000],
+                ],
+            ],
+            [
+                'plan' => [
+                    'name'        => '【露天風呂付き客室】絶景プレミアムプラン',
+                    'description' => '客室に露天風呂が付いた特別なプランです。四季折々の絶景を眺めながら、贅沢なひとときをお楽しみいただけます。2食付き。',
+                ],
+                'prices' => [
+                    [$deluxe, 45000],
+                    [$suite,  80000],
+                ],
+            ],
+            [
+                'plan' => [
+                    'name'        => '【記念日・特別】アニバーサリープラン',
+                    'description' => '大切な方との記念日に。ウェルカムスイーツ・バルーン装飾・記念写真撮影サービスをご用意します。特別な思い出をお手伝いします。',
+                ],
+                'prices' => [
+                    [$deluxe, 50000],
+                    [$suite,  90000],
+                ],
+            ],
+            [
+                'plan' => [
+                    'name'        => '【素泊まり】お気軽ステイプラン',
+                    'description' => '食事なしで気軽にご利用いただけるプランです。近隣のレストランや温泉街をご自由にお楽しみください。',
+                ],
+                'prices' => [
+                    [$standard, 8000],
+                    [$deluxe,   13000],
+                    [$suite,    25000],
+                ],
+            ],
+        ];
+
+        foreach ($plans as $data) {
+            $plan = AccommodationPlan::create($data['plan']);
+
+            foreach ($data['prices'] as [$roomType, $price]) {
+                if ($roomType) {
+                    PlanRoomPrice::create([
+                        'accommodation_plan_id' => $plan->id,
+                        'room_type_id'          => $roomType->id,
+                        'price'                 => $price,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/hotel-reservation/src/database/seeders/DatabaseSeeder.php
+++ b/hotel-reservation/src/database/seeders/DatabaseSeeder.php
@@ -16,5 +16,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(AdminSeeder::class);
         $this->call(RoomTypeSeeder::class);
+        $this->call(AccommodationPlanSeeder::class);
     }
 }

--- a/hotel-reservation/src/resources/views/user/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/index.blade.php
@@ -3,19 +3,58 @@
 @section('title', '宿泊プラン一覧')
 
 @section('content')
-<h1>宿泊プラン一覧</h1>
 
-@forelse ($plans as $plan)
-    <div>
-        <h2>{{ $plan->name }}</h2>
-        @if ($plan->description)
-            <p>{{ $plan->description }}</p>
-        @endif
-        <a href="{{ route('user.plans.show', $plan) }}">詳細を見る</a>
+<section class="py-5 bg-light">
+    <div class="container">
+        <div class="text-center mb-5">
+            <p class="text-muted text-uppercase mb-2" style="letter-spacing: .2em; font-size: .75rem;">Plans</p>
+            <h1 class="h3 fw-light">宿泊プラン一覧</h1>
+        </div>
+
+        @forelse ($plans as $plan)
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="row g-0 align-items-center">
+                    @if ($plan->planImages->isNotEmpty())
+                        <div class="col-md-4">
+                            <img src="{{ Storage::url($plan->planImages->first()->image_path) }}"
+                                 class="img-fluid rounded-start h-100"
+                                 style="max-height: 220px; width: 100%; object-fit: cover;"
+                                 alt="{{ $plan->planImages->first()->name }}">
+                        </div>
+                        <div class="col-md-8">
+                    @else
+                        <div class="col-12">
+                    @endif
+                            <div class="card-body p-4">
+                                <h2 class="card-title h5 fw-semibold mb-2">{{ $plan->name }}</h2>
+                                @if ($plan->description)
+                                    <p class="card-text text-muted small mb-3">
+                                        {{ Str::limit($plan->description, 80) }}
+                                    </p>
+                                @endif
+                                @if ($plan->planRoomPrices->isNotEmpty())
+                                    <p class="mb-3 fw-semibold">
+                                        <span class="text-muted small">1泊 </span>
+                                        {{ number_format($plan->planRoomPrices->min('price')) }}円〜
+                                    </p>
+                                @endif
+                                <a href="{{ route('user.plans.show', $plan) }}" class="btn btn-dark btn-sm px-4">
+                                    詳細を見る →
+                                </a>
+                            </div>
+                    </div>
+                </div>
+            </div>
+        @empty
+            <div class="text-center py-5">
+                <p class="text-muted">現在公開中のプランはありません。</p>
+            </div>
+        @endforelse
+
+        <div class="d-flex justify-content-center mt-4">
+            {{ $plans->links() }}
+        </div>
     </div>
-@empty
-    <p>現在公開中のプランはありません。</p>
-@endforelse
+</section>
 
-{{ $plans->links() }}
 @endsection

--- a/hotel-reservation/src/resources/views/user/plan/show.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/show.blade.php
@@ -3,41 +3,63 @@
 @section('title'){{ $plan->name }}@endsection
 
 @section('content')
-<a href="{{ route('user.plans.index') }}">← プラン一覧へ</a>
 
-<h1>{{ $plan->name }}</h1>
+<section class="py-5">
+    <div class="container" style="max-width: 800px;">
 
-@if ($plan->planImages->isNotEmpty())
-    <div>
-        @foreach ($plan->planImages as $image)
-            <img src="{{ Storage::url($image->image_path) }}" alt="{{ $image->name }}">
-        @endforeach
+        <nav aria-label="breadcrumb" class="mb-4">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ route('user.plans.index') }}">宿泊プラン一覧</a></li>
+                <li class="breadcrumb-item active" aria-current="page">{{ $plan->name }}</li>
+            </ol>
+        </nav>
+
+        <h1 class="h2 fw-light mb-4">{{ $plan->name }}</h1>
+
+        @if ($plan->planImages->isNotEmpty())
+            <div class="row g-2 mb-4">
+                @foreach ($plan->planImages as $image)
+                    <div class="col-md-6">
+                        <img src="{{ Storage::url($image->image_path) }}"
+                             class="img-fluid rounded"
+                             style="width: 100%; height: 240px; object-fit: cover;"
+                             alt="{{ $image->name }}">
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        @if ($plan->description)
+            <p class="text-muted lh-lg mb-4">{{ $plan->description }}</p>
+        @endif
+
+        @if ($plan->planRoomPrices->isNotEmpty())
+            <h2 class="h5 fw-semibold mb-3">料金</h2>
+            <table class="table table-bordered mb-5">
+                <thead class="table-light">
+                    <tr>
+                        <th>部屋タイプ</th>
+                        <th>1泊料金</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($plan->planRoomPrices as $price)
+                        <tr>
+                            <td>{{ $price->roomType->name }}</td>
+                            <td>{{ number_format($price->price) }}円</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        @endif
+
+        <div class="d-grid gap-2 col-md-6">
+            <a href="{{ route('user.plans.calendar', $plan) }}" class="btn btn-dark btn-lg">
+                空室カレンダーを確認する →
+            </a>
+        </div>
+
     </div>
-@endif
+</section>
 
-@if ($plan->description)
-    <p>{{ $plan->description }}</p>
-@endif
-
-@if ($plan->planRoomPrices->isNotEmpty())
-    <h2>料金</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>部屋タイプ</th>
-                <th>1泊料金</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach ($plan->planRoomPrices as $price)
-                <tr>
-                    <td>{{ $price->roomType->name }}</td>
-                    <td>{{ number_format($price->price) }}円</td>
-                </tr>
-            @endforeach
-        </tbody>
-    </table>
-@endif
-
-<a href="{{ route('user.plans.calendar', $plan) }}">空室カレンダーを確認する</a>
 @endsection

--- a/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\User\Plan;
 
 use App\Models\AccommodationPlan;
+use App\Models\PlanImage;
 use App\Models\PlanRoomPrice;
 use App\Models\RoomType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -29,6 +30,32 @@ class PlanControllerTest extends TestCase
         $this->get(route('user.plans.index'))
             ->assertOk()
             ->assertSee('絶景プラン');
+    }
+
+    public function test_プラン一覧にプランの画像が表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        PlanImage::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'image_path'            => 'plans/test-image.jpg',
+        ]);
+
+        $this->get(route('user.plans.index'))
+            ->assertOk()
+            ->assertSee('plans/test-image.jpg', false);
+    }
+
+    public function test_プラン一覧に最低料金が表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'price'                 => 12000,
+        ]);
+
+        $this->get(route('user.plans.index'))
+            ->assertOk()
+            ->assertSee('12,000');
     }
 
     public function test_削除済みのプランは一覧に表示されない(): void


### PR DESCRIPTION
## Summary

- プラン一覧をカードレイアウトに変更（サムネイル画像・最低料金を表示）
- プラン詳細にパンくずリスト・Bootstrap テーブル・CTA ボタンを追加
- `IndexController` に `planRoomPrices` の eager load を追加
- `AccommodationPlanSeeder` を追加（5件のサンプルプランデータ）

## Test（TDD）

新規テストを先に追加し、失敗を確認してから実装：
- `test_プラン一覧にプランの画像が表示される`
- `test_プラン一覧に最低料金が表示される`

## Related

Closes #119