### PR TITLE
feat: 空室カレンダーページの UI 改善（Bootstrap）(#120)

### DIFF
--- a/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
@@ -3,61 +3,88 @@
 @section('title')空室カレンダー - {{ $plan->name }}@endsection
 
 @section('content')
-<a href="{{ route('user.plans.show', $plan) }}">← プラン詳細へ</a>
 
-<h1>{{ $plan->name }} — 空室カレンダー</h1>
-<h2>{{ $firstDay->format('Y年n月') }}</h2>
+<section class="py-5">
+    <div class="container" style="max-width: 760px;">
 
-<table border="1">
-    <thead>
-        <tr>
-            <th>日</th>
-            <th>月</th>
-            <th>火</th>
-            <th>水</th>
-            <th>木</th>
-            <th>金</th>
-            <th>土</th>
-        </tr>
-    </thead>
-    <tbody>
+        <nav aria-label="breadcrumb" class="mb-4">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ route('user.plans.index') }}">宿泊プラン一覧</a></li>
+                <li class="breadcrumb-item"><a href="{{ route('user.plans.show', $plan) }}">{{ $plan->name }}</a></li>
+                <li class="breadcrumb-item active" aria-current="page">空室カレンダー</li>
+            </ol>
+        </nav>
+
+        <h1 class="h3 fw-light mb-1">{{ $plan->name }}</h1>
+        <p class="text-muted mb-4">空室カレンダー</p>
+
+        {{-- 月ナビゲーション --}}
         @php
-            $startDow = $firstDay->dayOfWeek; // 0=Sun
-            $cellIndex = 0;
+            $prevMonth = $firstDay->copy()->subMonth();
+            $nextMonth = $firstDay->copy()->addMonth();
         @endphp
-        <tr>
-            @for ($i = 0; $i < $startDow; $i++)
-                <td></td>
-                @php $cellIndex++ @endphp
-            @endfor
+        <div class="d-flex align-items-center justify-content-between mb-3">
+            <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $prevMonth->year, 'month' => $prevMonth->month]) }}"
+               class="btn btn-outline-secondary btn-sm">← 前月</a>
+            <h2 class="h5 mb-0">{{ $firstDay->format('Y年n月') }}</h2>
+            <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month]) }}"
+               class="btn btn-outline-secondary btn-sm">翌月 →</a>
+        </div>
 
-            @foreach ($calendar as $date => $info)
-                @if ($cellIndex > 0 && $cellIndex % 7 === 0)
-                    </tr><tr>
-                @endif
-                <td>
-                    {{ \Carbon\Carbon::parse($date)->day }}日<br>
-                    @if ($info['availability'] === \App\Enums\CalendarAvailability::Available)
-                        <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}">○</a>
-                    @elseif ($info['availability'] === \App\Enums\CalendarAvailability::Limited)
-                        <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}">△</a>
-                    @else
-                        ×
-                    @endif
-                </td>
-                @php $cellIndex++ @endphp
-            @endforeach
-        </tr>
-    </tbody>
-</table>
+        {{-- カレンダーテーブル --}}
+        <table class="table table-bordered text-center align-middle mb-4">
+            <thead class="table-light">
+                <tr>
+                    <th class="text-danger">日</th>
+                    <th>月</th>
+                    <th>火</th>
+                    <th>水</th>
+                    <th>木</th>
+                    <th>金</th>
+                    <th class="text-primary">土</th>
+                </tr>
+            </thead>
+            <tbody>
+                @php
+                    $startDow  = $firstDay->dayOfWeek;
+                    $cellIndex = 0;
+                @endphp
+                <tr>
+                    @for ($i = 0; $i < $startDow; $i++)
+                        <td class="bg-light"></td>
+                        @php $cellIndex++ @endphp
+                    @endfor
 
-<div>
-    @php
-        $prevMonth = $firstDay->copy()->subMonth();
-        $nextMonth = $firstDay->copy()->addMonth();
-    @endphp
-    <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $prevMonth->year, 'month' => $prevMonth->month]) }}">← 前月</a>
-    &nbsp;
-    <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month]) }}">翌月 →</a>
-</div>
+                    @foreach ($calendar as $date => $info)
+                        @if ($cellIndex > 0 && $cellIndex % 7 === 0)
+                            </tr><tr>
+                        @endif
+                        <td style="height: 64px;">
+                            <div class="small text-muted mb-1">{{ \Carbon\Carbon::parse($date)->day }}</div>
+                            @if ($info['availability'] === \App\Enums\CalendarAvailability::Available)
+                                <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}"
+                                   class="btn btn-success btn-sm px-2 py-0 fw-bold">○</a>
+                            @elseif ($info['availability'] === \App\Enums\CalendarAvailability::Limited)
+                                <a href="{{ route('user.reservations.create', ['slot_id' => $info['slot_id'], 'plan_id' => $plan->id]) }}"
+                                   class="btn btn-warning btn-sm px-2 py-0 fw-bold">△</a>
+                            @else
+                                <span class="text-muted">×</span>
+                            @endif
+                        </td>
+                        @php $cellIndex++ @endphp
+                    @endforeach
+                </tr>
+            </tbody>
+        </table>
+
+        {{-- 凡例 --}}
+        <div class="d-flex gap-3 justify-content-center small text-muted">
+            <span><span class="badge bg-success me-1">○</span>空室あり</span>
+            <span><span class="badge bg-warning text-dark me-1">△</span>残りわずか</span>
+            <span><span class="text-muted me-1">×</span>満室</span>
+        </div>
+
+    </div>
+</section>
+
 @endsection

--- a/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
@@ -22,6 +22,17 @@ class CalendarControllerTest extends TestCase
             ->assertOk();
     }
 
+    public function test_カレンダーに凡例が表示される(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+
+        $this->get(route('user.plans.calendar', $plan))
+            ->assertOk()
+            ->assertSee('空室あり')
+            ->assertSee('残りわずか')
+            ->assertSee('満室');
+    }
+
     public function test_削除済みプランは404になる(): void
     {
         $plan = AccommodationPlan::factory()->create();


### PR DESCRIPTION
## Summary

- カレンダーテーブルを Bootstrap スタイルに刷新（日曜赤・土曜青）
- ○ → btn-success、△ → btn-warning のボタンリンクに変更
- 凡例（空室あり・残りわずか・満室）を追加
- パンくずリスト・月ナビゲーションボタンを追加

## Test（TDD）

- `test_カレンダーに凡例が表示される` を先に追加し、失敗を確認してから実装

## Related

Closes #120