### PR TITLE
feat: 予約フォーム・確認・完了ページの UI 改善（Bootstrap）(#121)

### DIFF
--- a/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/complete.blade.php
@@ -3,7 +3,22 @@
 @section('title', '予約完了')
 
 @section('content')
-<h1>予約が完了しました</h1>
-<p>ご予約ありがとうございます。確認メールをお送りします。</p>
-<a href="/">TOPページへ</a>
+
+<section class="py-5">
+    <div class="container" style="max-width: 560px;">
+        <div class="text-center py-5">
+            <div class="mb-4" style="font-size: 3rem;">✓</div>
+            <h1 class="h3 fw-light mb-3">予約が完了しました</h1>
+            <p class="text-muted mb-5">
+                ご予約ありがとうございます。<br>
+                確認メールをお送りします。
+            </p>
+            <div class="d-flex flex-column flex-sm-row gap-3 justify-content-center">
+                <a href="{{ route('user.plans.index') }}" class="btn btn-dark px-4">他のプランを見る</a>
+                <a href="{{ url('/') }}" class="btn btn-outline-secondary px-4">TOPページへ</a>
+            </div>
+        </div>
+    </div>
+</section>
+
 @endsection

--- a/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/confirm.blade.php
@@ -3,27 +3,44 @@
 @section('title', '予約内容確認')
 
 @section('content')
-<h1>予約内容確認</h1>
-<p>以下の内容で予約を確定します。よろしければ「予約を確定する」ボタンを押してください。</p>
 
-<table border="1">
-    <tr><th>プラン</th><td>{{ $plan->name }}</td></tr>
-    <tr><th>日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
-    <tr><th>料金</th><td>{{ number_format($price) }}円</td></tr>
-    <tr><th>氏名</th><td>{{ $validated['last_name'] }} {{ $validated['first_name'] }}</td></tr>
-    <tr><th>メールアドレス</th><td>{{ $validated['email'] }}</td></tr>
-    <tr><th>住所</th><td>{{ $validated['address'] }}</td></tr>
-    <tr><th>電話番号</th><td>{{ $validated['phone'] }}</td></tr>
-    <tr><th>メッセージ</th><td>{{ $validated['message'] ?? '—' }}</td></tr>
-</table>
+<section class="py-5">
+    <div class="container" style="max-width: 680px;">
 
-<form action="{{ route('user.reservations.store') }}" method="POST">
-    @csrf
-    @foreach ($validated as $key => $value)
-        <input type="hidden" name="{{ $key }}" value="{{ $value }}">
-    @endforeach
-    <button type="submit">予約を確定する</button>
-</form>
+        <h1 class="h3 fw-light mb-2">予約内容確認</h1>
+        <p class="text-muted mb-4">以下の内容で予約を確定します。よろしければ「予約を確定する」ボタンを押してください。</p>
 
-<a href="{{ route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]) }}">← 入力に戻る</a>
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body p-4">
+                <table class="table table-bordered mb-0">
+                    <tr><th class="table-light" style="width:9em;">プラン</th><td>{{ $plan->name }}</td></tr>
+                    <tr><th class="table-light">日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
+                    <tr><th class="table-light">料金</th><td class="fw-semibold">{{ number_format($price) }}円</td></tr>
+                    <tr><th class="table-light">氏名</th><td>{{ $validated['last_name'] }} {{ $validated['first_name'] }}</td></tr>
+                    <tr><th class="table-light">メールアドレス</th><td>{{ $validated['email'] }}</td></tr>
+                    <tr><th class="table-light">住所</th><td>{{ $validated['address'] }}</td></tr>
+                    <tr><th class="table-light">電話番号</th><td>{{ $validated['phone'] }}</td></tr>
+                    <tr><th class="table-light">メッセージ</th><td>{{ $validated['message'] ?? '—' }}</td></tr>
+                </table>
+            </div>
+        </div>
+
+        <form action="{{ route('user.reservations.store') }}" method="POST">
+            @csrf
+            @foreach ($validated as $key => $value)
+                <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+            @endforeach
+            <div class="d-grid mb-3">
+                <button type="submit" class="btn btn-dark btn-lg">予約を確定する</button>
+            </div>
+        </form>
+
+        <div class="text-center">
+            <a href="{{ route('user.reservations.create', ['slot_id' => $slot->id, 'plan_id' => $plan->id]) }}"
+               class="text-muted small">← 入力に戻る</a>
+        </div>
+
+    </div>
+</section>
+
 @endsection

--- a/hotel-reservation/src/resources/views/user/reservation/create.blade.php
+++ b/hotel-reservation/src/resources/views/user/reservation/create.blade.php
@@ -3,36 +3,85 @@
 @section('title', '予約フォーム')
 
 @section('content')
-<h1>予約フォーム</h1>
 
-<table border="1">
-    <tr><th>プラン</th><td>{{ $plan->name }}</td></tr>
-    <tr><th>日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
-    <tr><th>料金</th><td>{{ number_format($price) }}円</td></tr>
-</table>
+<section class="py-5">
+    <div class="container" style="max-width: 680px;">
 
-@if ($errors->any())
-    <ul style="color:red">
-        @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-        @endforeach
-    </ul>
-@endif
+        <h1 class="h3 fw-light mb-4">予約フォーム</h1>
 
-<form action="{{ route('user.reservations.confirm') }}" method="POST" novalidate>
-    @csrf
-    <input type="hidden" name="slot_id" value="{{ $slot->id }}">
-    <input type="hidden" name="plan_id" value="{{ $plan->id }}">
+        {{-- 予約内容サマリー --}}
+        <div class="card border-0 bg-light mb-4">
+            <div class="card-body">
+                <table class="table table-sm mb-0">
+                    <tr><th class="text-muted fw-normal" style="width:6em;">プラン</th><td class="fw-semibold">{{ $plan->name }}</td></tr>
+                    <tr><th class="text-muted fw-normal">日程</th><td>{{ $slot->start->format('Y/m/d') }} 〜 {{ $slot->end->format('Y/m/d') }}</td></tr>
+                    <tr><th class="text-muted fw-normal">料金</th><td class="fw-semibold">{{ number_format($price) }}円</td></tr>
+                </table>
+            </div>
+        </div>
 
-    <p>
-        <label>姓 <span style="color:red">*</span>：<input type="text" name="last_name" value="{{ old('last_name') }}" required></label>
-        <label>名 <span style="color:red">*</span>：<input type="text" name="first_name" value="{{ old('first_name') }}" required></label>
-    </p>
-    <p><label>メールアドレス <span style="color:red">*</span>：<input type="email" name="email" value="{{ old('email') }}" required></label></p>
-    <p><label>住所 <span style="color:red">*</span>：<input type="text" name="address" value="{{ old('address') }}" required size="50"></label></p>
-    <p><label>電話番号 <span style="color:red">*</span>：<input type="tel" name="phone" value="{{ old('phone') }}" required></label></p>
-    <p><label>ホテルへのメッセージ：<br><textarea name="message" rows="4" cols="50">{{ old('message') }}</textarea></label></p>
+        @if ($errors->any())
+            <div class="alert alert-danger mb-4">
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
 
-    <button type="submit">確認画面へ</button>
-</form>
+        <form action="{{ route('user.reservations.confirm') }}" method="POST" novalidate>
+            @csrf
+            <input type="hidden" name="slot_id" value="{{ $slot->id }}">
+            <input type="hidden" name="plan_id" value="{{ $plan->id }}">
+
+            <div class="row g-3 mb-3">
+                <div class="col-sm-6">
+                    <label class="form-label">姓 <span class="text-danger">*</span></label>
+                    <input type="text" name="last_name" value="{{ old('last_name') }}"
+                           class="form-control @error('last_name') is-invalid @enderror" required>
+                    @error('last_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-sm-6">
+                    <label class="form-label">名 <span class="text-danger">*</span></label>
+                    <input type="text" name="first_name" value="{{ old('first_name') }}"
+                           class="form-control @error('first_name') is-invalid @enderror" required>
+                    @error('first_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">メールアドレス <span class="text-danger">*</span></label>
+                <input type="email" name="email" value="{{ old('email') }}"
+                       class="form-control @error('email') is-invalid @enderror" required>
+                @error('email')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">住所 <span class="text-danger">*</span></label>
+                <input type="text" name="address" value="{{ old('address') }}"
+                       class="form-control @error('address') is-invalid @enderror" required>
+                @error('address')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">電話番号 <span class="text-danger">*</span></label>
+                <input type="tel" name="phone" value="{{ old('phone') }}"
+                       class="form-control @error('phone') is-invalid @enderror" required>
+                @error('phone')<div class="invalid-feedback">{{ $message }}</div>@enderror
+            </div>
+
+            <div class="mb-4">
+                <label class="form-label">ホテルへのメッセージ</label>
+                <textarea name="message" rows="4" class="form-control">{{ old('message') }}</textarea>
+            </div>
+
+            <div class="d-grid">
+                <button type="submit" class="btn btn-dark btn-lg">確認画面へ →</button>
+            </div>
+        </form>
+
+    </div>
+</section>
+
 @endsection

--- a/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
@@ -102,6 +102,23 @@ class ReservationFlowControllerTest extends TestCase
     }
 
     // ----------------------------------------------------------------
+    // CompleteController
+    // ----------------------------------------------------------------
+
+    public function test_予約完了ページが表示される(): void
+    {
+        $this->get(route('user.reservations.complete'))
+            ->assertOk();
+    }
+
+    public function test_予約完了ページに他プラン誘導リンクがある(): void
+    {
+        $this->get(route('user.reservations.complete'))
+            ->assertOk()
+            ->assertSee('他のプランを見る');
+    }
+
+    // ----------------------------------------------------------------
     // ヘルパー
     // ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- 予約フォーム: Bootstrap form-control・バリデーションエラー inline 表示・予約内容サマリーカード
- 確認ページ: Bootstrap table・shadow カード・入力に戻るリンク
- 完了ページ: チェックマーク・「他のプランを見る」CTA ボタンを追加

## Test（TDD）

- `test_予約完了ページが表示される` を追加
- `test_予約完了ページに他プラン誘導リンクがある` を先に追加し、失敗を確認してから実装

## Related

Closes #121