### PR TITLE
feat: 空室カレンダーへの部屋タイプ別タブ追加および検証用Seederの実装 (#130)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/User/Plan/CalendarController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Plan/CalendarController.php
@@ -13,12 +13,14 @@ class CalendarController extends Controller
 {
     public function __invoke(Request $request, AccommodationPlan $plan, CalendarService $service): View
     {
-        $year  = $request->integer('year', (int) now()->format('Y'));
-        $month = $request->integer('month', (int) now()->format('n'));
+        $year       = $request->integer('year', (int) now()->format('Y'));
+        $month      = $request->integer('month', (int) now()->format('n'));
+        $roomTypeId = $request->integer('room_type_id') ?: null;
 
-        $calendar  = $service->getMonthlyAvailability($plan, $year, $month);
+        $roomTypes = $plan->planRoomPrices()->with('roomType')->get()->pluck('roomType');
+        $calendar  = $service->getMonthlyAvailability($plan, $year, $month, $roomTypeId);
         $firstDay  = Carbon::create($year, $month, 1);
 
-        return view('user.plan.calendar', compact('plan', 'calendar', 'firstDay'));
+        return view('user.plan.calendar', compact('plan', 'calendar', 'firstDay', 'roomTypes', 'roomTypeId'));
     }
 }

--- a/hotel-reservation/src/app/Services/CalendarService.php
+++ b/hotel-reservation/src/app/Services/CalendarService.php
@@ -17,9 +17,11 @@ class CalendarService
      * @return array<string, array{availability: CalendarAvailability, slot_id: int|null}>
      *         キーは 'Y-m-d' 形式の日付文字列
      */
-    public function getMonthlyAvailability(AccommodationPlan $plan, int $year, int $month): array
+    public function getMonthlyAvailability(AccommodationPlan $plan, int $year, int $month, ?int $roomTypeId = null): array
     {
-        $roomTypeIds = $plan->planRoomPrices()->pluck('room_type_id')->all();
+        $roomTypeIds = $roomTypeId !== null
+            ? [$roomTypeId]
+            : $plan->planRoomPrices()->pluck('room_type_id')->all();
 
         $firstDay = Carbon::create($year, $month, 1);
         $lastDay  = $firstDay->copy()->endOfMonth();

--- a/hotel-reservation/src/database/seeders/DatabaseSeeder.php
+++ b/hotel-reservation/src/database/seeders/DatabaseSeeder.php
@@ -17,5 +17,6 @@ class DatabaseSeeder extends Seeder
         $this->call(AdminSeeder::class);
         $this->call(RoomTypeSeeder::class);
         $this->call(AccommodationPlanSeeder::class);
+        $this->call(ReservationSlotSeeder::class);
     }
 }

--- a/hotel-reservation/src/database/seeders/ReservationSlotSeeder.php
+++ b/hotel-reservation/src/database/seeders/ReservationSlotSeeder.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\ReservationSlot;
+use App\Models\RoomType;
+use Carbon\Carbon;
+use Carbon\CarbonPeriod;
+use Illuminate\Database\Seeder;
+
+class ReservationSlotSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $standard = RoomType::where('name', 'スタンダードルーム')->first();
+        $deluxe   = RoomType::where('name', 'デラックスルーム')->first();
+        $suite    = RoomType::where('name', 'スイートルーム')->first();
+
+        // 2026年5〜7月分の予約枠を投入
+        $startMonth = Carbon::create(2026, 5, 1);
+        $endMonth   = Carbon::create(2026, 7, 31);
+        $period     = CarbonPeriod::create($startMonth, $endMonth);
+
+        foreach ($period as $day) {
+            $dateStr = $day->toDateString();
+            $endStr  = $day->copy()->addDay()->toDateString();
+
+            // 土日は人気が高い → 満室に近い日を増やす
+            $isWeekend = $day->isWeekend();
+            $dayOfMonth = $day->day;
+
+            // スタンダードルーム（定員3）
+            $this->createSlots($standard, $dateStr, $endStr, $isWeekend, $dayOfMonth, maxCount: 3);
+
+            // デラックスルーム（定員2）
+            $this->createSlots($deluxe, $dateStr, $endStr, $isWeekend, $dayOfMonth, maxCount: 2);
+
+            // スイートルーム（定員1）
+            $this->createSlots($suite, $dateStr, $endStr, $isWeekend, $dayOfMonth, maxCount: 1);
+        }
+    }
+
+    private function createSlots(
+        ?RoomType $roomType,
+        string $dateStr,
+        string $endStr,
+        bool $isWeekend,
+        int $dayOfMonth,
+        int $maxCount,
+    ): void {
+        if (! $roomType) {
+            return;
+        }
+
+        // 月末付近（25日以降）や週末は埋まりやすい
+        if ($isWeekend && $dayOfMonth >= 25) {
+            // 満室：Bookedスロットを定員分
+            for ($i = 0; $i < $maxCount; $i++) {
+                ReservationSlot::create([
+                    'room_type_id' => $roomType->id,
+                    'start'        => $dateStr,
+                    'end'          => $endStr,
+                    'status'       => ReservationSlotStatus::Booked,
+                ]);
+            }
+        } elseif ($isWeekend || $dayOfMonth >= 20) {
+            // 残りわずか：Available 1 + Booked 残り
+            ReservationSlot::create([
+                'room_type_id' => $roomType->id,
+                'start'        => $dateStr,
+                'end'          => $endStr,
+                'status'       => ReservationSlotStatus::Available,
+            ]);
+            for ($i = 1; $i < $maxCount; $i++) {
+                ReservationSlot::create([
+                    'room_type_id' => $roomType->id,
+                    'start'        => $dateStr,
+                    'end'          => $endStr,
+                    'status'       => ReservationSlotStatus::Booked,
+                ]);
+            }
+        } else {
+            // 空室あり：Available を定員分
+            for ($i = 0; $i < $maxCount; $i++) {
+                ReservationSlot::create([
+                    'room_type_id' => $roomType->id,
+                    'start'        => $dateStr,
+                    'end'          => $endStr,
+                    'status'       => ReservationSlotStatus::Available,
+                ]);
+            }
+        }
+    }
+}

--- a/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
+++ b/hotel-reservation/src/resources/views/user/plan/calendar.blade.php
@@ -16,18 +16,44 @@
         </nav>
 
         <h1 class="h3 fw-light mb-1">{{ $plan->name }}</h1>
-        <p class="text-muted mb-4">空室カレンダー</p>
+        <p class="text-muted mb-3">空室カレンダー</p>
+
+        {{-- 部屋タイプタブ --}}
+        @if ($roomTypes->isNotEmpty())
+        <ul class="nav nav-tabs mb-4">
+            <li class="nav-item">
+                <a class="nav-link {{ $roomTypeId === null ? 'active' : '' }}"
+                   href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $firstDay->year, 'month' => $firstDay->month]) }}">
+                    全室タイプ
+                </a>
+            </li>
+            @foreach ($roomTypes as $roomType)
+            <li class="nav-item">
+                <a class="nav-link {{ $roomTypeId === $roomType->id ? 'active' : '' }}"
+                   href="{{ route('user.plans.calendar', ['plan' => $plan, 'room_type_id' => $roomType->id, 'year' => $firstDay->year, 'month' => $firstDay->month]) }}">
+                    {{ $roomType->name }}
+                </a>
+            </li>
+            @endforeach
+        </ul>
+        @endif
 
         {{-- 月ナビゲーション --}}
         @php
-            $prevMonth = $firstDay->copy()->subMonth();
-            $nextMonth = $firstDay->copy()->addMonth();
+            $prevMonth  = $firstDay->copy()->subMonth();
+            $nextMonth  = $firstDay->copy()->addMonth();
+            $prevParams = ['plan' => $plan, 'year' => $prevMonth->year, 'month' => $prevMonth->month];
+            $nextParams = ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month];
+            if ($roomTypeId !== null) {
+                $prevParams['room_type_id'] = $roomTypeId;
+                $nextParams['room_type_id'] = $roomTypeId;
+            }
         @endphp
         <div class="d-flex align-items-center justify-content-between mb-3">
-            <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $prevMonth->year, 'month' => $prevMonth->month]) }}"
+            <a href="{{ route('user.plans.calendar', $prevParams) }}"
                class="btn btn-outline-secondary btn-sm">← 前月</a>
             <h2 class="h5 mb-0">{{ $firstDay->format('Y年n月') }}</h2>
-            <a href="{{ route('user.plans.calendar', ['plan' => $plan, 'year' => $nextMonth->year, 'month' => $nextMonth->month]) }}"
+            <a href="{{ route('user.plans.calendar', $nextParams) }}"
                class="btn btn-outline-secondary btn-sm">翌月 →</a>
         </div>
 

--- a/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/CalendarControllerTest.php
@@ -22,6 +22,54 @@ class CalendarControllerTest extends TestCase
             ->assertOk();
     }
 
+    public function test_カレンダーに部屋タイプのタブが表示される(): void
+    {
+        $roomType = RoomType::factory()->create(['name' => 'スタンダードルーム']);
+        $plan     = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType->id,
+        ]);
+
+        $this->get(route('user.plans.calendar', $plan))
+            ->assertOk()
+            ->assertSee('スタンダードルーム');
+    }
+
+    public function test_部屋タイプを指定するとその部屋タイプの空室のみ表示される(): void
+    {
+        $roomType1 = RoomType::factory()->create();
+        $roomType2 = RoomType::factory()->create();
+        $plan      = AccommodationPlan::factory()->create();
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType1->id,
+        ]);
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $roomType2->id,
+        ]);
+        $slot1 = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType1->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+        $slot2 = ReservationSlot::factory()->create([
+            'room_type_id' => $roomType1->id,
+            'start'        => '2026-06-01',
+            'end'          => '2026-06-02',
+            'status'       => ReservationSlotStatus::Available,
+        ]);
+
+        // roomType2 を指定 → roomType1 の枠は無視されて予約リンクが出ない
+        $this->get(route('user.plans.calendar', ['plan' => $plan, 'room_type_id' => $roomType2->id, 'year' => 2026, 'month' => 6]))
+            ->assertOk()
+            ->assertSee('×')
+            ->assertDontSee(route('user.reservations.create', ['slot_id' => $slot1->id, 'plan_id' => $plan->id]))
+            ->assertDontSee(route('user.reservations.create', ['slot_id' => $slot2->id, 'plan_id' => $plan->id]));
+    }
+
     public function test_カレンダーに凡例が表示される(): void
     {
         $plan = AccommodationPlan::factory()->create();


### PR DESCRIPTION
## Summary
空室カレンダーにおいて、ユーザーが「部屋タイプ別」に空室状況を確認し、予約に進めるようにUIおよびバックエンドのロジックを改修しました。
また、カレンダー上で「○（空室あり）」「△（残りわずか）」「×（満室）」の表示デザインを実際のデータで検証するため、数ヶ月分の予約枠データを自動生成するSeederを追加しています。

## 具体的な変更内容

### 1. 部屋タイプ別タブの実装（同期処理）
- `calendar.blade.php` に Bootstrap5 の `nav-tabs` を使用した部屋タイプ切り替えタブを追加しました。
- UIの確実性とシステム全体の複雑化を防ぐため、JSでの非同期通信ではなく、`room_type_id` クエリパラメータを用いたページリロード（同期処理）で実装しています。
- 前月・翌月の月切り替えナビゲーションクリック時にも、現在選択中の `room_type_id` が正しく引き継がれるように修正しました。

### 2. バックエンドのロジック改修
- `CalendarController` にて `room_type_id` クエリパラメータを受け取り、全部屋タイプ一覧（タブ描画用）とともにビューへ渡す処理を追加しました。
- `CalendarService::getMonthlyAvailability` メソッドに `roomTypeId` 引数を追加し、指定された部屋タイプの予約枠（Slot）のみを集計・判定するように修正しました。

### 3. UI検証用Seederの追加 (`ReservationSlotSeeder`)
- 5〜7月（92日分）の予約枠を、部屋タイプ（スタンダード・デラックス・スイートなど）と曜日のパターンに合わせて自動生成する処理を追加しました。
- UIで3段階のステータスが確認できるよう、意図的に以下のパターンでデータを投入しています。
  - 平日序盤: 空室あり (○)
  - 平日後半・土日: 残りわずか (△)
  - 土日月末: 満室 (×)

## 動作確認手順
1. `php artisan migrate:fresh --seed` を実行し、データが初期化・投入されることを確認する。
2. 宿泊者側の「宿泊プラン一覧」から任意のプラン詳細を開き、空室カレンダーへ遷移する。
3. カレンダー上部に部屋タイプのタブが表示され、クリックで切り替わる（URLに `?room_type_id=X` が付与される）ことを確認する。
4. カレンダーの「○/△/×」表示が、タブごとに正しく切り替わることを確認する。
5. 前月・翌月に移動した際も、選択中の部屋タイプが維持されることを確認する。

