### PR TITLE
feat: 管理者側各ページの UI 改善（Bootstrap・サイドバーレイアウト）(#122)

### DIFF
--- a/hotel-reservation/src/resources/views/admin/auth/login.blade.php
+++ b/hotel-reservation/src/resources/views/admin/auth/login.blade.php
@@ -3,26 +3,47 @@
 @section('title', '管理者ログイン')
 
 @section('content')
-<h1>管理者ログイン</h1>
 
-@if ($errors->any())
-    <ul>
-        @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-        @endforeach
-    </ul>
-@endif
+<div class="container" style="max-width: 420px;">
+    <div class="text-center mb-4 mt-4">
+        <h1 class="h4 fw-bold">管理者ログイン</h1>
+    </div>
 
-<form method="POST" action="{{ route('admin.login.store') }}" novalidate>
-    @csrf
-    <div>
-        <label for="email">メールアドレス</label>
-        <input type="email" id="email" name="email" value="{{ old('email') }}" required>
+    @if ($errors->any())
+        <div class="alert alert-danger mb-3">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <div class="card shadow-sm">
+        <div class="card-body p-4">
+            <form method="POST" action="{{ route('admin.login.store') }}" novalidate>
+                @csrf
+
+                <div class="mb-3">
+                    <label for="email" class="form-label">メールアドレス</label>
+                    <input type="email" id="email" name="email" value="{{ old('email') }}"
+                           class="form-control @error('email') is-invalid @enderror" required autofocus>
+                    @error('email')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="password" class="form-label">パスワード</label>
+                    <input type="password" id="password" name="password"
+                           class="form-control @error('password') is-invalid @enderror" required>
+                    @error('password')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-dark">ログイン</button>
+                </div>
+            </form>
+        </div>
     </div>
-    <div>
-        <label for="password">パスワード</label>
-        <input type="password" id="password" name="password" required>
-    </div>
-    <button type="submit">ログイン</button>
-</form>
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/dashboard.blade.php
+++ b/hotel-reservation/src/resources/views/admin/dashboard.blade.php
@@ -3,11 +3,50 @@
 @section('title', 'ダッシュボード')
 
 @section('content')
-<h1>管理者ダッシュボード</h1>
-<p>ログイン中: {{ Auth::guard('admin')->user()->last_name }} {{ Auth::guard('admin')->user()->first_name }}</p>
-<form method="POST" action="{{ route('admin.logout') }}">
-    @csrf
-    @method('DELETE')
-    <button type="submit">ログアウト</button>
-</form>
+
+<div class="container">
+    <div class="d-flex align-items-center justify-content-between mb-4">
+        <h1 class="h4 fw-bold mb-0">ダッシュボード</h1>
+        <span class="text-muted small">
+            ログイン中: {{ Auth::guard('admin')->user()->last_name }} {{ Auth::guard('admin')->user()->first_name }}
+        </span>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-4">
+            <a href="{{ route('admin.plans.index') }}" class="text-decoration-none">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body text-center py-4">
+                        <div class="fs-1 mb-2">📋</div>
+                        <h5 class="card-title fw-bold">プラン管理</h5>
+                        <p class="card-text text-muted small">宿泊プランの作成・編集・削除</p>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-4">
+            <a href="{{ route('admin.reservation-slots.index') }}" class="text-decoration-none">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body text-center py-4">
+                        <div class="fs-1 mb-2">🗓️</div>
+                        <h5 class="card-title fw-bold">予約枠管理</h5>
+                        <p class="card-text text-muted small">予約枠の作成・編集・削除</p>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-4">
+            <a href="{{ route('admin.reservations.index') }}" class="text-decoration-none">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body text-center py-4">
+                        <div class="fs-1 mb-2">📝</div>
+                        <h5 class="card-title fw-bold">予約管理</h5>
+                        <p class="card-text text-muted small">予約の確認・キャンセル</p>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
@@ -1,31 +1,84 @@
 @extends('layouts.admin')
 
-@section('title', '宿泊プラン編集')
+@section('title', 'プラン編集')
 
 @section('content')
-<h1>宿泊プラン編集</h1>
-<a href="{{ route('admin.plans.index') }}">← 一覧へ</a>
 
-<form action="{{ route('admin.plans.update', $plan) }}" method="POST" enctype="multipart/form-data" novalidate>
-    @csrf
-    @method('PUT')
-    <label>プラン名 <span style="color:red">*</span>：<input type="text" name="name" value="{{ old('name', $plan->name) }}" required></label>
-    <label>説明：<textarea name="description">{{ old('description', $plan->description) }}</textarea></label>
-    <label>画像（変更する場合のみ）：<input type="file" name="images[]" multiple accept="image/*"></label>
-    @foreach ($roomTypes as $roomType)
-        @php $price = $plan->planRoomPrices->firstWhere('room_type_id', $roomType->id) @endphp
-        <label>{{ $roomType->name }} 料金：
-            <input type="number" name="prices[{{ $roomType->id }}]" min="0"
-                   value="{{ old("prices.{$roomType->id}", $price?->price) }}">
-        </label>
-    @endforeach
+<div class="container" style="max-width: 680px;">
+
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ route('admin.plans.index') }}">プラン管理</a></li>
+            <li class="breadcrumb-item active" aria-current="page">編集</li>
+        </ol>
+    </nav>
+
+    <h1 class="h4 fw-bold mb-4">プラン編集</h1>
+
     @if ($errors->any())
-        <ul style="color:red">
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
+        <div class="alert alert-danger mb-3">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
     @endif
-    <button type="submit">更新</button>
-</form>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <form action="{{ route('admin.plans.update', $plan) }}" method="POST" enctype="multipart/form-data" novalidate>
+                @csrf
+                @method('PUT')
+
+                <div class="mb-3">
+                    <label class="form-label">プラン名 <span class="text-danger">*</span></label>
+                    <input type="text" name="name" value="{{ old('name', $plan->name) }}"
+                           class="form-control @error('name') is-invalid @enderror" required>
+                    @error('name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">説明</label>
+                    <textarea name="description" rows="3" class="form-control">{{ old('description', $plan->description) }}</textarea>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">画像（変更する場合のみ）</label>
+                    <input type="file" name="images[]" multiple accept="image/*" class="form-control">
+                    @if ($plan->planImages->isNotEmpty())
+                        <div class="d-flex gap-2 flex-wrap mt-2">
+                            @foreach ($plan->planImages as $image)
+                                <img src="{{ \Illuminate\Support\Facades\Storage::url($image->path) }}" alt="" style="height:60px; object-fit:cover; border-radius:4px;">
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+
+                <div class="mb-4">
+                    <label class="form-label">部屋タイプ別料金</label>
+                    <div class="row g-2">
+                        @foreach ($roomTypes as $roomType)
+                            @php $price = $plan->planRoomPrices->firstWhere('room_type_id', $roomType->id) @endphp
+                            <div class="col-sm-4">
+                                <label class="form-label small text-muted">{{ $roomType->name }}</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" name="prices[{{ $roomType->id }}]" min="0"
+                                           value="{{ old("prices.{$roomType->id}", $price?->price) }}"
+                                           class="form-control @error("prices.{$roomType->id}") is-invalid @enderror"
+                                           placeholder="未設定">
+                                    <span class="input-group-text">円</span>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+
+                <button type="submit" class="btn btn-dark">更新</button>
+            </form>
+        </div>
+    </div>
+
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/plan/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/index.blade.php
@@ -1,57 +1,114 @@
 @extends('layouts.admin')
 
-@section('title', '宿泊プラン管理')
+@section('title', 'プラン管理')
 
 @section('content')
-<h1>宿泊プラン管理</h1>
-<a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
 
-<h2>プラン作成</h2>
-<form action="{{ route('admin.plans.store') }}" method="POST" enctype="multipart/form-data" novalidate>
-    @csrf
-    <label>プラン名 <span style="color:red">*</span>：<input type="text" name="name" value="{{ old('name') }}" required></label>
-    <label>説明：<textarea name="description">{{ old('description') }}</textarea></label>
-    <label>画像：<input type="file" name="images[]" multiple accept="image/*"></label>
-    @foreach ($roomTypes as $roomType)
-        <label>{{ $roomType->name }} 料金：
-            <input type="number" name="prices[{{ $roomType->id }}]" min="0">
-        </label>
-    @endforeach
+<div class="container">
+
+    <h1 class="h4 fw-bold mb-4">プラン管理</h1>
+
     @if ($errors->any())
-        <ul style="color:red">
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
+        <div class="alert alert-danger mb-4">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
     @endif
-    <button type="submit">作成</button>
-</form>
 
-<h2>プラン一覧</h2>
-<table>
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>プラン名</th>
-            <th>操作</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach ($plans as $plan)
-            <tr>
-                <td>{{ $plan->id }}</td>
-                <td>{{ $plan->name }}</td>
-                <td>
-                    <a href="{{ route('admin.plans.edit', $plan) }}">編集</a>
-                    <form action="{{ route('admin.plans.destroy', $plan) }}" method="POST" style="display:inline">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit">削除</button>
-                    </form>
-                </td>
-            </tr>
-        @endforeach
-    </tbody>
-</table>
-{{ $plans->links() }}
+    {{-- プラン作成フォーム --}}
+    <div class="card shadow-sm border-0 mb-4">
+        <div class="card-header bg-white fw-semibold">プラン作成</div>
+        <div class="card-body">
+            <form action="{{ route('admin.plans.store') }}" method="POST" enctype="multipart/form-data" novalidate>
+                @csrf
+
+                <div class="mb-3">
+                    <label class="form-label">プラン名 <span class="text-danger">*</span></label>
+                    <input type="text" name="name" value="{{ old('name') }}"
+                           class="form-control @error('name') is-invalid @enderror" required>
+                    @error('name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">説明</label>
+                    <textarea name="description" rows="3" class="form-control">{{ old('description') }}</textarea>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">画像</label>
+                    <input type="file" name="images[]" multiple accept="image/*" class="form-control">
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">部屋タイプ別料金</label>
+                    <div class="row g-2">
+                        @foreach ($roomTypes as $roomType)
+                            <div class="col-sm-4">
+                                <label class="form-label small text-muted">{{ $roomType->name }}</label>
+                                <div class="input-group input-group-sm">
+                                    <input type="number" name="prices[{{ $roomType->id }}]" min="0"
+                                           value="{{ old("prices.{$roomType->id}") }}"
+                                           class="form-control @error("prices.{$roomType->id}") is-invalid @enderror"
+                                           placeholder="未設定">
+                                    <span class="input-group-text">円</span>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+
+                <button type="submit" class="btn btn-dark btn-sm">作成</button>
+            </form>
+        </div>
+    </div>
+
+    {{-- プラン一覧 --}}
+    <div class="card shadow-sm border-0">
+        <div class="card-header bg-white fw-semibold">プラン一覧</div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>プラン名</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($plans as $plan)
+                            <tr>
+                                <td class="text-muted small">{{ $plan->id }}</td>
+                                <td>{{ $plan->name }}</td>
+                                <td class="text-end">
+                                    <a href="{{ route('admin.plans.edit', $plan) }}"
+                                       class="btn btn-outline-secondary btn-sm me-1">編集</a>
+                                    <form action="{{ route('admin.plans.destroy', $plan) }}" method="POST"
+                                          style="display:inline" onsubmit="return confirm('削除しますか？')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center text-muted py-4">プランがありません</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        {{ $plans->links() }}
+    </div>
+
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/edit.blade.php
@@ -3,49 +3,67 @@
 @section('title', '予約枠編集')
 
 @section('content')
-<h1>予約枠編集</h1>
-<a href="{{ route('admin.reservation-slots.index') }}">← 一覧へ戻る</a>
 
-@if (session('error'))
-    <p style="color:red">{{ session('error') }}</p>
-@endif
-@if ($errors->any())
-    <ul style="color:red">
-        @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-        @endforeach
-    </ul>
-@endif
+<div class="container" style="max-width: 560px;">
 
-<form action="{{ route('admin.reservation-slots.update', $reservationSlot) }}" method="POST" novalidate>
-    @csrf
-    @method('PUT')
+    <nav aria-label="breadcrumb" class="mb-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ route('admin.reservation-slots.index') }}">予約枠管理</a></li>
+            <li class="breadcrumb-item active" aria-current="page">編集</li>
+        </ol>
+    </nav>
 
-    <p>
-        <label>部屋タイプ <span style="color:red">*</span>：
-            <select name="room_type_id" required>
-                @foreach ($roomTypes as $roomType)
-                    <option value="{{ $roomType->id }}"
-                        @selected(old('room_type_id', $reservationSlot->room_type_id) == $roomType->id)>
-                        {{ $roomType->name }}（{{ $roomType->count }}室）
-                    </option>
+    <h1 class="h4 fw-bold mb-4">予約枠編集</h1>
+
+    @if (session('error'))
+        <div class="alert alert-danger mb-3">{{ session('error') }}</div>
+    @endif
+
+    @if ($errors->any())
+        <div class="alert alert-danger mb-3">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
                 @endforeach
-            </select>
-        </label>
-    </p>
-    <p>
-        <label>チェックイン <span style="color:red">*</span>：
-            <input type="date" name="start"
-                   value="{{ old('start', $reservationSlot->start->format('Y-m-d')) }}" required>
-        </label>
-    </p>
-    <p>
-        <label>チェックアウト <span style="color:red">*</span>：
-            <input type="date" name="end"
-                   value="{{ old('end', $reservationSlot->end->format('Y-m-d')) }}" required>
-        </label>
-    </p>
+            </ul>
+        </div>
+    @endif
 
-    <button type="submit">更新</button>
-</form>
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <form action="{{ route('admin.reservation-slots.update', $reservationSlot) }}" method="POST" novalidate>
+                @csrf
+                @method('PUT')
+
+                <div class="mb-3">
+                    <label class="form-label">部屋タイプ <span class="text-danger">*</span></label>
+                    <select name="room_type_id" class="form-select" required>
+                        @foreach ($roomTypes as $roomType)
+                            <option value="{{ $roomType->id }}"
+                                @selected(old('room_type_id', $reservationSlot->room_type_id) == $roomType->id)>
+                                {{ $roomType->name }}（{{ $roomType->count }}室）
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">チェックイン <span class="text-danger">*</span></label>
+                    <input type="date" name="start" class="form-control"
+                           value="{{ old('start', $reservationSlot->start->format('Y-m-d')) }}" required>
+                </div>
+
+                <div class="mb-4">
+                    <label class="form-label">チェックアウト <span class="text-danger">*</span></label>
+                    <input type="date" name="end" class="form-control"
+                           value="{{ old('end', $reservationSlot->end->format('Y-m-d')) }}" required>
+                </div>
+
+                <button type="submit" class="btn btn-dark">更新</button>
+            </form>
+        </div>
+    </div>
+
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation-slot/index.blade.php
@@ -3,99 +3,161 @@
 @section('title', '予約枠管理')
 
 @section('content')
-<h1>予約枠管理</h1>
-<a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a>
 
-@if (session('success'))
-    <p style="color:green">{{ session('success') }}</p>
-@endif
-@if (session('error'))
-    <p style="color:red">{{ session('error') }}</p>
-@endif
+<div class="container">
 
-<h2>個別作成</h2>
-<form action="{{ route('admin.reservation-slots.store') }}" method="POST" novalidate>
-    @csrf
-    <label>部屋タイプ <span style="color:red">*</span>：
-        <select name="room_type_id" required>
-            <option value="">選択してください</option>
-            @foreach ($roomTypes as $roomType)
-                <option value="{{ $roomType->id }}" @selected(old('room_type_id') == $roomType->id)>
-                    {{ $roomType->name }}（{{ $roomType->count }}室）
-                </option>
-            @endforeach
-        </select>
-    </label>
-    <label>チェックイン <span style="color:red">*</span>：<input type="date" name="start" value="{{ old('start') }}" required></label>
-    <label>チェックアウト <span style="color:red">*</span>：<input type="date" name="end" value="{{ old('end') }}" required></label>
-    <button type="submit">作成</button>
-</form>
-@if ($errors->any())
-    <ul style="color:red">
-        @foreach ($errors->all() as $error)
-            <li>{{ $error }}</li>
-        @endforeach
-    </ul>
-@endif
+    <h1 class="h4 fw-bold mb-4">予約枠管理</h1>
 
-<h2>期間一括作成</h2>
-<form action="{{ route('admin.reservation-slots.bulk-store') }}" method="POST" novalidate>
-    @csrf
-    <label>部屋タイプ <span style="color:red">*</span>：
-        <select name="room_type_id" required>
-            <option value="">選択してください</option>
-            @foreach ($roomTypes as $roomType)
-                <option value="{{ $roomType->id }}">
-                    {{ $roomType->name }}（{{ $roomType->count }}室）
-                </option>
-            @endforeach
-        </select>
-    </label>
-    <label>開始日 <span style="color:red">*</span>：<input type="date" name="from" required></label>
-    <label>終了日（最終チェックアウト日） <span style="color:red">*</span>：<input type="date" name="to" required></label>
-    <button type="submit">一括作成</button>
-    <small>※開始日〜終了日の前日まで、1泊ずつ予約枠を作成します。定員に達した日程はスキップします。</small>
-</form>
+    @if (session('success'))
+        <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+        </div>
+    @endif
+    @if (session('error'))
+        <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+            {{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+        </div>
+    @endif
 
-<h2>予約枠一覧</h2>
-<table border="1">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>部屋タイプ</th>
-            <th>チェックイン</th>
-            <th>チェックアウト</th>
-            <th>ステータス</th>
-            <th>操作</th>
-        </tr>
-    </thead>
-    <tbody>
-        @forelse ($slots as $slot)
-            <tr>
-                <td>{{ $slot->id }}</td>
-                <td>{{ $slot->roomType->name }}</td>
-                <td>{{ $slot->start->format('Y/m/d') }}</td>
-                <td>{{ $slot->end->format('Y/m/d') }}</td>
-                <td>{{ $slot->status->name }}</td>
-                <td>
-                    @if ($slot->status->name === 'Available')
-                        <a href="{{ route('admin.reservation-slots.edit', $slot) }}">編集</a>
-                        <form action="{{ route('admin.reservation-slots.destroy', $slot) }}" method="POST" style="display:inline"
-                              onsubmit="return confirm('削除しますか？')">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit">削除</button>
-                        </form>
-                    @else
-                        予約済み
-                    @endif
-                </td>
-            </tr>
-        @empty
-            <tr><td colspan="6">予約枠がありません</td></tr>
-        @endforelse
-    </tbody>
-</table>
+    @if ($errors->any())
+        <div class="alert alert-danger mb-4">
+            <ul class="mb-0">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
 
-{{ $slots->links() }}
+    <div class="row g-4 mb-4">
+        {{-- 個別作成 --}}
+        <div class="col-md-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-white fw-semibold">個別作成</div>
+                <div class="card-body">
+                    <form action="{{ route('admin.reservation-slots.store') }}" method="POST" novalidate>
+                        @csrf
+                        <div class="mb-3">
+                            <label class="form-label">部屋タイプ <span class="text-danger">*</span></label>
+                            <select name="room_type_id" class="form-select" required>
+                                <option value="">選択してください</option>
+                                @foreach ($roomTypes as $roomType)
+                                    <option value="{{ $roomType->id }}" @selected(old('room_type_id') == $roomType->id)>
+                                        {{ $roomType->name }}（{{ $roomType->count }}室）
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">チェックイン <span class="text-danger">*</span></label>
+                            <input type="date" name="start" value="{{ old('start') }}" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">チェックアウト <span class="text-danger">*</span></label>
+                            <input type="date" name="end" value="{{ old('end') }}" class="form-control" required>
+                        </div>
+                        <button type="submit" class="btn btn-dark btn-sm">作成</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        {{-- 期間一括作成 --}}
+        <div class="col-md-6">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-header bg-white fw-semibold">期間一括作成</div>
+                <div class="card-body">
+                    <form action="{{ route('admin.reservation-slots.bulk-store') }}" method="POST" novalidate>
+                        @csrf
+                        <div class="mb-3">
+                            <label class="form-label">部屋タイプ <span class="text-danger">*</span></label>
+                            <select name="room_type_id" class="form-select" required>
+                                <option value="">選択してください</option>
+                                @foreach ($roomTypes as $roomType)
+                                    <option value="{{ $roomType->id }}">
+                                        {{ $roomType->name }}（{{ $roomType->count }}室）
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">開始日 <span class="text-danger">*</span></label>
+                            <input type="date" name="from" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">終了日（最終チェックアウト日） <span class="text-danger">*</span></label>
+                            <input type="date" name="to" class="form-control" required>
+                        </div>
+                        <button type="submit" class="btn btn-dark btn-sm">一括作成</button>
+                        <p class="text-muted small mt-2 mb-0">※開始日〜終了日の前日まで、1泊ずつ予約枠を作成します。定員に達した日程はスキップします。</p>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- 予約枠一覧 --}}
+    <div class="card shadow-sm border-0">
+        <div class="card-header bg-white fw-semibold">予約枠一覧</div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>部屋タイプ</th>
+                            <th>チェックイン</th>
+                            <th>チェックアウト</th>
+                            <th>ステータス</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($slots as $slot)
+                            <tr>
+                                <td class="text-muted small">{{ $slot->id }}</td>
+                                <td>{{ $slot->roomType->name }}</td>
+                                <td>{{ $slot->start->format('Y/m/d') }}</td>
+                                <td>{{ $slot->end->format('Y/m/d') }}</td>
+                                <td>
+                                    @if ($slot->status === \App\Enums\ReservationSlotStatus::Available)
+                                        <span class="badge bg-success">空室</span>
+                                    @else
+                                        <span class="badge bg-warning text-dark">予約済み</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($slot->status === \App\Enums\ReservationSlotStatus::Available)
+                                        <a href="{{ route('admin.reservation-slots.edit', $slot) }}"
+                                           class="btn btn-outline-secondary btn-sm me-1">編集</a>
+                                        <form action="{{ route('admin.reservation-slots.destroy', $slot) }}" method="POST"
+                                              style="display:inline" onsubmit="return confirm('削除しますか？')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-outline-danger btn-sm">削除</button>
+                                        </form>
+                                    @else
+                                        <span class="text-muted small">—</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">予約枠がありません</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        {{ $slots->links() }}
+    </div>
+
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/reservation/index.blade.php
@@ -1,58 +1,86 @@
 @extends('layouts.admin')
 
-@section('title', '予約一覧')
+@section('title', '予約管理')
 
 @section('content')
-<h1>予約一覧</h1>
 
-@if (session('success'))
-    <p style="color:green">{{ session('success') }}</p>
-@endif
+<div class="container">
 
-<table border="1" cellpadding="8">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>宿泊者</th>
-            <th>プラン</th>
-            <th>部屋タイプ</th>
-            <th>日程</th>
-            <th>料金</th>
-            <th>ステータス</th>
-            <th>操作</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach ($reservations as $reservation)
-            <tr>
-                <td>{{ $reservation->id }}</td>
-                <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
-                <td>{{ $reservation->plan_name }}</td>
-                <td>{{ $reservation->reservationSlot->roomType->name }}</td>
-                <td>
-                    {{ $reservation->reservationSlot->start->format('Y/m/d') }}
-                    〜
-                    {{ $reservation->reservationSlot->end->format('Y/m/d') }}
-                </td>
-                <td>{{ number_format($reservation->price) }}円</td>
-                <td>{{ $reservation->status->name }}</td>
-                <td>
-                    @if ($reservation->status === \App\Enums\ReservationStatus::Confirmed)
-                        <form action="{{ route('admin.reservations.cancel', $reservation) }}" method="POST">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" onclick="return confirm('キャンセルしますか？')">キャンセル</button>
-                        </form>
-                    @else
-                        —
-                    @endif
-                </td>
-            </tr>
-        @endforeach
-    </tbody>
-</table>
+    <h1 class="h4 fw-bold mb-4">予約管理</h1>
 
-{{ $reservations->links() }}
+    @if (session('success'))
+        <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+        </div>
+    @endif
 
-<p><a href="{{ route('admin.dashboard') }}">← ダッシュボードへ</a></p>
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>宿泊者</th>
+                            <th>プラン</th>
+                            <th>部屋タイプ</th>
+                            <th>日程</th>
+                            <th>料金</th>
+                            <th>ステータス</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($reservations as $reservation)
+                            <tr>
+                                <td class="text-muted small">{{ $reservation->id }}</td>
+                                <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
+                                <td>{{ $reservation->plan_name }}</td>
+                                <td>{{ $reservation->reservationSlot->roomType->name }}</td>
+                                <td class="small">
+                                    {{ $reservation->reservationSlot->start->format('Y/m/d') }}
+                                    〜
+                                    {{ $reservation->reservationSlot->end->format('Y/m/d') }}
+                                </td>
+                                <td>{{ number_format($reservation->price) }}円</td>
+                                <td>
+                                    @if ($reservation->status === \App\Enums\ReservationStatus::Confirmed)
+                                        <span class="badge bg-primary">確定</span>
+                                    @else
+                                        <span class="badge bg-secondary">キャンセル済み</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    @if ($reservation->status === \App\Enums\ReservationStatus::Confirmed)
+                                        <form action="{{ route('admin.reservations.cancel', $reservation) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-outline-danger btn-sm"
+                                                    onclick="return confirm('キャンセルしますか？')">
+                                                キャンセル
+                                            </button>
+                                        </form>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="8" class="text-center text-muted py-4">予約データがありません</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        {{ $reservations->links() }}
+    </div>
+
+</div>
+
 @endsection

--- a/hotel-reservation/src/resources/views/layouts/admin-nav.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin-nav.blade.php
@@ -1,0 +1,21 @@
+<nav class="nav flex-column pt-2 px-2">
+    <a class="nav-link rounded mb-1 {{ request()->routeIs('admin.dashboard') ? 'bg-secondary' : 'text-white-50' }} text-white"
+       href="{{ route('admin.dashboard') }}">ダッシュボード</a>
+
+    <div class="text-white-50 small px-3 pt-3 pb-1 text-uppercase" style="font-size:.7rem; letter-spacing:.08em;">予約</div>
+
+    <a class="nav-link rounded mb-1 {{ request()->routeIs('admin.reservations.*') ? 'bg-secondary' : 'text-white-50' }} text-white"
+       href="{{ route('admin.reservations.index') }}">予約一覧</a>
+
+    <a class="nav-link rounded mb-1 {{ request()->routeIs('admin.reservation-slots.*') ? 'bg-secondary' : 'text-white-50' }} text-white"
+       href="{{ route('admin.reservation-slots.index') }}">予約枠管理</a>
+
+    <div class="text-white-50 small px-3 pt-3 pb-1 text-uppercase" style="font-size:.7rem; letter-spacing:.08em;">コンテンツ</div>
+
+    <a class="nav-link rounded mb-1 {{ request()->routeIs('admin.plans.*') ? 'bg-secondary' : 'text-white-50' }} text-white"
+       href="{{ route('admin.plans.index') }}">プラン一覧</a>
+
+    <div class="text-white-50 small px-3 pt-3 pb-1 text-uppercase" style="font-size:.7rem; letter-spacing:.08em;">その他</div>
+
+    <span class="nav-link rounded mb-1 text-white-50">お問い合わせ一覧</span>
+</nav>

--- a/hotel-reservation/src/resources/views/layouts/admin.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin.blade.php
@@ -6,7 +6,7 @@
     <title>@yield('title', '管理画面') | {{ config('app.name') }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
-<body>
+<body class="bg-light">
     @auth('admin')
     <nav class="navbar navbar-expand-lg bg-dark navbar-dark shadow-sm">
         <div class="container">
@@ -40,7 +40,7 @@
     </nav>
     @endauth
 
-    <main>
+    <main class="py-4">
         @yield('content')
     </main>
 </body>

--- a/hotel-reservation/src/resources/views/layouts/admin.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin.blade.php
@@ -7,41 +7,81 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body class="bg-light">
-    @auth('admin')
-    <nav class="navbar navbar-expand-lg bg-dark navbar-dark shadow-sm">
-        <div class="container">
-            <a class="navbar-brand" href="{{ route('admin.dashboard') }}">管理画面</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#adminNav" aria-controls="adminNav" aria-expanded="false" aria-label="メニューを開く">
+
+    {{-- ===== 固定ヘッダー ===== --}}
+    <nav class="navbar bg-dark navbar-dark shadow-sm fixed-top" style="height:56px;">
+        <div class="container-fluid px-3">
+
+            {{-- モバイル：ハンバーガーボタン + サイト名 --}}
+            @auth('admin')
+            <button class="navbar-toggler d-lg-none me-2" type="button"
+                    data-bs-toggle="offcanvas" data-bs-target="#adminOffcanvas"
+                    aria-controls="adminOffcanvas" aria-label="メニューを開く">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse" id="adminNav">
-                <ul class="navbar-nav me-auto">
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ route('admin.plans.index') }}">プラン管理</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ route('admin.reservation-slots.index') }}">予約枠管理</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="{{ route('admin.reservations.index') }}">予約管理</a>
-                    </li>
-                </ul>
-                <ul class="navbar-nav ms-auto">
-                    <li class="nav-item">
-                        <form method="POST" action="{{ route('admin.logout') }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-outline-light btn-sm">ログアウト</button>
-                        </form>
-                    </li>
-                </ul>
+            @endauth
+
+            <a class="navbar-brand fw-bold" href="{{ route('admin.dashboard') }}">管理画面</a>
+
+            <div class="ms-auto d-flex align-items-center gap-2">
+                {{-- 表サイトへ --}}
+                <a href="{{ url('/') }}" class="btn btn-outline-light btn-sm" target="_blank">
+                    表サイトへ
+                </a>
+                {{-- ログアウト --}}
+                @auth('admin')
+                <form method="POST" action="{{ route('admin.logout') }}" class="mb-0">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-outline-light btn-sm">ログアウト</button>
+                </form>
+                @endauth
             </div>
         </div>
     </nav>
+
+    @auth('admin')
+    {{-- ===== モバイル用 Offcanvas サイドメニュー ===== --}}
+    <div class="offcanvas offcanvas-start bg-dark text-white" tabindex="-1"
+         id="adminOffcanvas" aria-labelledby="adminOffcanvasLabel">
+        <div class="offcanvas-header border-bottom border-secondary">
+            <h5 class="offcanvas-title" id="adminOffcanvasLabel">管理メニュー</h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="閉じる"></button>
+        </div>
+        <div class="offcanvas-body p-0">
+            @include('layouts.admin-nav')
+        </div>
+    </div>
     @endauth
 
-    <main class="py-4">
-        @yield('content')
-    </main>
+    <div class="d-flex" style="padding-top:56px; min-height:100vh;">
+
+        @auth('admin')
+        {{-- ===== 左固定サイドバー（デスクトップのみ表示）===== --}}
+        <aside class="d-none d-lg-block bg-dark text-white"
+               style="width:220px; min-width:220px; position:fixed; top:56px; left:0; height:calc(100vh - 56px); overflow-y:auto; z-index:99;">
+            @include('layouts.admin-nav')
+        </aside>
+
+        {{-- ===== メインコンテンツ ===== --}}
+        <main class="flex-grow-1 p-4" style="margin-left:0;" id="adminMain">
+            @yield('content')
+        </main>
+
+        <style>
+            @media (min-width: 992px) {
+                #adminMain { margin-left: 220px; }
+            }
+        </style>
+
+        @else
+        {{-- 未認証（ログイン画面など） --}}
+        <main class="flex-grow-1 p-4">
+            @yield('content')
+        </main>
+        @endauth
+
+    </div>
+
 </body>
 </html>

--- a/hotel-reservation/src/tests/Feature/Admin/AdminLayoutTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/AdminLayoutTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Admin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AdminLayoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::create([
+            'last_name'  => '山田',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+    }
+
+    public function test_ヘッダーに表サイトへのリンクがある(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk()
+            ->assertSee('表サイトへ');
+    }
+
+    public function test_サイドバーにダッシュボードリンクがある(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk()
+            ->assertSee('ダッシュボード');
+    }
+
+    public function test_サイドバーにお問い合わせ一覧メニューがある(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk()
+            ->assertSee('お問い合わせ');
+    }
+
+    public function test_スマホ向けOffcanvasメニューにナビゲーションがある(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.plans.index'))
+            ->assertOk()
+            ->assertSee('offcanvas');
+    }
+}

--- a/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
@@ -70,6 +70,27 @@ class ReservationControllerTest extends TestCase
             ->assertSee($reservation->last_name);
     }
 
+    public function test_予約一覧に確定ステータスが日本語で表示される(): void
+    {
+        $this->makeConfirmedReservation();
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservations.index'))
+            ->assertOk()
+            ->assertSee('確定');
+    }
+
+    public function test_予約一覧にキャンセル済みステータスが日本語で表示される(): void
+    {
+        $reservation = $this->makeConfirmedReservation();
+        $reservation->update(['status' => ReservationStatus::Cancelled]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservations.index'))
+            ->assertOk()
+            ->assertSee('キャンセル済み');
+    }
+
     // ----------------------------------------------------------------
     // CancelController
     // ----------------------------------------------------------------

--- a/hotel-reservation/src/tests/Feature/Admin/ReservationSlot/ReservationSlotControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/ReservationSlot/ReservationSlotControllerTest.php
@@ -97,6 +97,26 @@ class ReservationSlotControllerTest extends TestCase
             ->assertSee('2026/07/01');
     }
 
+    public function test_予約枠一覧に空室ステータスが日本語で表示される(): void
+    {
+        ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservation-slots.index'))
+            ->assertOk()
+            ->assertSee('空室');
+    }
+
+    public function test_予約枠一覧に予約済みステータスが日本語で表示される(): void
+    {
+        ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Booked]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.reservation-slots.index'))
+            ->assertOk()
+            ->assertSee('予約済み');
+    }
+
     // ----------------------------------------------------------------
     // StoreController
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- 管理者側全ページを Bootstrap 5 でリデザイン
- ヘッダー＋左固定サイドバー＋メインエリアの3ペイン構成に変更
- ステータスラベルを日本語バッジ化（空室/予約済み・確定/キャンセル済み）

## 変更内容

### レイアウト
- `layouts/admin.blade.php`: fixed-top ヘッダー・左固定サイドバー（デスクトップ）・Offcanvas モバイルメニューの3ペイン構成
- ヘッダー: サイト名・表サイトへリンク・ログアウトボタン
- サイドバー: ダッシュボード / 予約一覧 / 予約枠管理 / プラン一覧 / お問い合わせ一覧（プレースホルダー）
- `layouts/admin-nav.blade.php`: サイドバーと Offcanvas で共有するナビパーシャル

### 各ページ
- `admin/auth/login.blade.php`: Bootstrap カードフォーム
- `admin/dashboard.blade.php`: 3セクションへのナビカード
- `admin/plan/index.blade.php`: 作成フォームカード化・Bootstrap テーブル
- `admin/plan/edit.blade.php`: Bootstrap フォーム・既存画像サムネイル
- `admin/reservation-slot/index.blade.php`: 2フォームカード化・空室/予約済みバッジ
- `admin/reservation-slot/edit.blade.php`: Bootstrap フォーム・パンくず
- `admin/reservation/index.blade.php`: 確定/キャンセル済みバッジ

### TDD テスト（7件追加）
- `AdminLayoutTest`: 表サイトへリンク・ダッシュボードリンク・お問い合わせメニュー・Offcanvas
- `ReservationControllerTest`: 確定・キャンセル済みの日本語ステータス
- `ReservationSlotControllerTest`: 空室・予約済みの日本語ステータス

## Test plan

- [x] ブラウザでデスクトップ表示（サイドバーが表示されること）
- [x] ブラウザでモバイル表示（サイドバーが隠れ、ハンバーガーから Offcanvas が開くこと）
- [x] 予約一覧・予約枠管理のステータスバッジが日本語で表示されること
- [x] ヘッダーの「表サイトへ」リンクが別タブで開くこと
- [x] CI グリーン（108件）
