### PR TITLE
feat: 各種システムメールの実装（予約完了・キャンセル完了）(#98)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
@@ -3,15 +3,19 @@
 namespace App\Http\Controllers\Admin\Reservation;
 
 use App\Http\Controllers\Controller;
+use App\Mail\ReservationCancelledMail;
 use App\Models\Reservation;
 use App\Services\ReservationService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Mail;
 
 class CancelController extends Controller
 {
     public function __invoke(Reservation $reservation, ReservationService $service): RedirectResponse
     {
         $service->cancel($reservation);
+
+        Mail::send(new ReservationCancelledMail($reservation));
 
         return redirect()->route('admin.reservations.index')->with('success', '予約をキャンセルしました。');
     }

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
@@ -3,11 +3,15 @@
 namespace App\Http\Controllers\User\Reservation;
 
 use App\Http\Controllers\Controller;
+use App\Mail\ReservationConfirmedMail;
+use App\Mail\ReservationReceivedMail;
 use App\Models\AccommodationPlan;
+use App\Models\Admin;
 use App\Models\ReservationSlot;
 use App\Services\ReservationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 
 class StoreController extends Controller
 {
@@ -30,9 +34,15 @@ class StoreController extends Controller
         $guestData = array_diff_key($validated, ['slot_id' => '', 'plan_id' => '']);
 
         try {
-            $service->reserve($slot, $plan, $guestData);
+            $reservation = $service->reserve($slot, $plan, $guestData);
         } catch (\RuntimeException $e) {
             return back()->withErrors(['slot_id' => $e->getMessage()]);
+        }
+
+        Mail::send(new ReservationConfirmedMail($reservation));
+
+        foreach (Admin::all() as $admin) {
+            Mail::send(new ReservationReceivedMail($reservation, $admin->email));
         }
 
         return redirect()->route('user.reservations.complete');

--- a/hotel-reservation/src/app/Mail/ReservationReceivedMail.php
+++ b/hotel-reservation/src/app/Mail/ReservationReceivedMail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ReservationReceivedMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly Reservation $reservation,
+        public readonly string $adminEmail,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            to:      [$this->adminEmail],
+            subject: '予約受付のお知らせ',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.reservation.received',
+        );
+    }
+}

--- a/hotel-reservation/src/resources/views/mail/reservation/received.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/received.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>予約受付のお知らせ</title>
+</head>
+<body>
+    <p>管理者様</p>
+
+    <p>新しい予約を受け付けました。</p>
+
+    <table>
+        <tr>
+            <th>氏名</th>
+            <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
+        </tr>
+        <tr>
+            <th>メールアドレス</th>
+            <td>{{ $reservation->email }}</td>
+        </tr>
+        <tr>
+            <th>プラン名</th>
+            <td>{{ $reservation->plan_name }}</td>
+        </tr>
+        <tr>
+            <th>料金</th>
+            <td>{{ number_format($reservation->price) }} 円</td>
+        </tr>
+    </table>
+
+    <p>{{ config('app.name') }}</p>
+</body>
+</html>

--- a/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Admin\Reservation;
 
 use App\Enums\ReservationSlotStatus;
 use App\Enums\ReservationStatus;
+use App\Mail\ReservationCancelledMail;
 use App\Models\AccommodationPlan;
 use App\Models\Admin;
 use App\Models\PlanRoomPrice;
@@ -12,6 +13,7 @@ use App\Models\ReservationSlot;
 use App\Models\RoomType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class ReservationControllerTest extends TestCase
@@ -105,6 +107,17 @@ class ReservationControllerTest extends TestCase
 
         $this->assertSame(ReservationStatus::Cancelled, $reservation->fresh()->status);
         $this->assertSame(ReservationSlotStatus::Available, $reservation->reservationSlot->fresh()->status);
+    }
+
+    public function test_予約キャンセル後に宿泊者へキャンセル完了メールが送信される(): void
+    {
+        Mail::fake();
+        $reservation = $this->makeConfirmedReservation();
+
+        $this->actingAs($this->admin, 'admin')
+            ->delete(route('admin.reservations.cancel', $reservation));
+
+        Mail::assertSent(ReservationCancelledMail::class, fn ($mail) => $mail->hasTo($reservation->email));
     }
 
     public function test_キャンセル済みの予約を再キャンセルしても冪等に動作する(): void

--- a/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
@@ -3,11 +3,16 @@
 namespace Tests\Feature\User\Reservation;
 
 use App\Enums\ReservationSlotStatus;
+use App\Mail\ReservationConfirmedMail;
+use App\Mail\ReservationReceivedMail;
 use App\Models\AccommodationPlan;
+use App\Models\Admin;
 use App\Models\PlanRoomPrice;
 use App\Models\ReservationSlot;
 use App\Models\RoomType;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class ReservationFlowControllerTest extends TestCase
@@ -99,6 +104,32 @@ class ReservationFlowControllerTest extends TestCase
             ->assertSessionHasErrors(['slot_id', 'plan_id', 'last_name', 'first_name', 'email', 'address', 'phone']);
 
         $this->assertDatabaseCount('reservations', 0);
+    }
+
+    public function test_予約完了後に宿泊者へ予約完了メールが送信される(): void
+    {
+        Mail::fake();
+        [$slot, $plan] = $this->makeAvailableSlotAndPlan();
+
+        $this->post(route('user.reservations.store'), $this->postData($slot->id, $plan->id));
+
+        Mail::assertSent(ReservationConfirmedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
+    }
+
+    public function test_予約完了後に管理者へ予約受付メールが送信される(): void
+    {
+        Mail::fake();
+        Admin::create([
+            'last_name'  => '管理',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+        [$slot, $plan] = $this->makeAvailableSlotAndPlan();
+
+        $this->post(route('user.reservations.store'), $this->postData($slot->id, $plan->id));
+
+        Mail::assertSent(ReservationReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
     }
 
     // ----------------------------------------------------------------

--- a/hotel-reservation/src/tests/Unit/Mail/ReservationReceivedMailTest.php
+++ b/hotel-reservation/src/tests/Unit/Mail/ReservationReceivedMailTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\ReservationReceivedMail;
+use App\Models\Reservation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationReceivedMailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Reservation $reservation;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reservation = Reservation::factory()->create([
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'guest@example.com',
+            'plan_name'  => 'スタンダードプラン',
+            'price'      => 12000,
+        ]);
+    }
+
+    public function test_件名が予約受付のお知らせである(): void
+    {
+        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail->assertHasSubject('予約受付のお知らせ');
+    }
+
+    public function test_宛先が指定した管理者メールアドレスである(): void
+    {
+        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail->assertHasTo('admin@example.com');
+    }
+
+    public function test_本文に宿泊者の氏名が含まれる(): void
+    {
+        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail->assertSeeInHtml('田中');
+        $mail->assertSeeInHtml('花子');
+    }
+
+    public function test_本文にプラン名が含まれる(): void
+    {
+        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail->assertSeeInHtml('スタンダードプラン');
+    }
+}


### PR DESCRIPTION
## Summary

- 予約完了時に宿泊者へ `ReservationConfirmedMail` を送信（`User/Reservation/StoreController`）
- 予約完了時に全管理者へ `ReservationReceivedMail` を送信（`User/Reservation/StoreController`）
- 予約キャンセル時に宿泊者へ `ReservationCancelledMail` を送信（`Admin/Reservation/CancelController`）
- `ReservationReceivedMail`（管理者向け予約受付メール）・メールビューを追加

## Test plan

- [x] `ReservationReceivedMailTest` Unit テスト（4件）green
- [x] StoreController メール送信 Feature テスト（2件）green
- [x] CancelController メール送信 Feature テスト（1件）green
- [x] 全テスト 123 件 green
- [x] Larastan level 6 / PHP CS Fixer 通過