### PR TITLE
feat: お問い合わせ機能の実装（宿泊者側フォーム・完了メール）(#99)

### DIFF
--- a/hotel-reservation/src/app/Enums/InquiryStatus.php
+++ b/hotel-reservation/src/app/Enums/InquiryStatus.php
@@ -6,4 +6,12 @@ enum InquiryStatus: int
 {
     case Unread = 1;
     case Read   = 2;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Unread => '問い合わせ中',
+            self::Read   => '完了',
+        };
+    }
 }

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/CompleteController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/CompleteController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\User\Contact;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+
+class CompleteController extends Controller
+{
+    public function __invoke(): View
+    {
+        return view('user.contact.complete');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/ConfirmController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/ConfirmController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\User\Contact;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ConfirmController extends Controller
+{
+    public function __invoke(Request $request): View
+    {
+        $validated = $request->validate([
+            'last_name'  => 'required|string|max:255',
+            'first_name' => 'required|string|max:255',
+            'email'      => 'required|email|max:255',
+            'address'    => 'required|string|max:255',
+            'phone'      => 'required|string|max:20',
+            'message'    => 'nullable|string',
+        ]);
+
+        return view('user.contact.confirm', compact('validated'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/CreateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/CreateController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\User\Contact;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+
+class CreateController extends Controller
+{
+    public function __invoke(): View
+    {
+        return view('user.contact.create');
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\User\Contact;
+
+use App\Http\Controllers\Controller;
+use App\Mail\InquiryCompletedMail;
+use App\Mail\InquiryReceivedMail;
+use App\Models\Admin;
+use App\Models\Inquiry;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+
+class StoreController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'last_name'  => 'required|string|max:255',
+            'first_name' => 'required|string|max:255',
+            'email'      => 'required|email|max:255',
+            'address'    => 'required|string|max:255',
+            'phone'      => 'required|string|max:20',
+            'message'    => 'nullable|string',
+        ]);
+
+        $inquiry = Inquiry::create($validated);
+
+        Mail::send(new InquiryCompletedMail($inquiry));
+
+        foreach (Admin::all() as $admin) {
+            Mail::send(new InquiryReceivedMail($inquiry, $admin->email));
+        }
+
+        return redirect()->route('user.contact.complete');
+    }
+}

--- a/hotel-reservation/src/app/Mail/InquiryCompletedMail.php
+++ b/hotel-reservation/src/app/Mail/InquiryCompletedMail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Inquiry;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class InquiryCompletedMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly Inquiry $inquiry)
+    {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            to:      [$this->inquiry->email],
+            subject: 'お問い合わせありがとうございます',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.inquiry.completed',
+        );
+    }
+}

--- a/hotel-reservation/src/app/Mail/InquiryReceivedMail.php
+++ b/hotel-reservation/src/app/Mail/InquiryReceivedMail.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Inquiry;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class InquiryReceivedMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly Inquiry $inquiry,
+        public readonly string $adminEmail,
+    ) {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            to:      [$this->adminEmail],
+            subject: 'お問い合わせを受け付けました',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.inquiry.received',
+        );
+    }
+}

--- a/hotel-reservation/src/resources/views/layouts/app.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/app.blade.php
@@ -28,7 +28,7 @@
                         <a class="nav-link" href="{{ route('user.access') }}">アクセス案内</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#">お問い合わせ</a>
+                        <a class="nav-link" href="{{ route('user.contact.create') }}">お問い合わせ</a>
                     </li>
                 </ul>
             </div>

--- a/hotel-reservation/src/resources/views/mail/inquiry/completed.blade.php
+++ b/hotel-reservation/src/resources/views/mail/inquiry/completed.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>お問い合わせありがとうございます</title>
+</head>
+<body>
+    <p>{{ $inquiry->last_name }} {{ $inquiry->first_name }} 様</p>
+
+    <p>お問い合わせをいただきありがとうございます。<br>
+    内容を確認のうえ、担当者よりご連絡いたします。</p>
+
+    <table>
+        <tr>
+            <th>お問い合わせ内容</th>
+            <td>{{ $inquiry->message }}</td>
+        </tr>
+    </table>
+
+    <p>{{ config('app.name') }}</p>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/mail/inquiry/received.blade.php
+++ b/hotel-reservation/src/resources/views/mail/inquiry/received.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>お問い合わせを受け付けました</title>
+</head>
+<body>
+    <p>管理者様</p>
+
+    <p>新しいお問い合わせを受け付けました。</p>
+
+    <table>
+        <tr>
+            <th>お名前</th>
+            <td>{{ $inquiry->last_name }} {{ $inquiry->first_name }}</td>
+        </tr>
+        <tr>
+            <th>メールアドレス</th>
+            <td>{{ $inquiry->email }}</td>
+        </tr>
+        <tr>
+            <th>住所</th>
+            <td>{{ $inquiry->address }}</td>
+        </tr>
+        <tr>
+            <th>電話番号</th>
+            <td>{{ $inquiry->phone }}</td>
+        </tr>
+        <tr>
+            <th>お問い合わせ内容</th>
+            <td>{{ $inquiry->message }}</td>
+        </tr>
+    </table>
+
+    <p>{{ config('app.name') }}</p>
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/user/contact/complete.blade.php
+++ b/hotel-reservation/src/resources/views/user/contact/complete.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.app')
+
+@section('title', 'お問い合わせ完了')
+
+@section('content')
+<div class="container py-5 text-center">
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <h1 class="h3 mb-3">お問い合わせを受け付けました</h1>
+            <p class="text-muted mb-4">
+                お問い合わせいただきありがとうございます。<br>
+                確認メールをお送りしましたのでご確認ください。<br>
+                担当者よりご連絡いたします。
+            </p>
+            <a href="{{ route('user.plans.index') }}" class="btn btn-outline-primary">
+                プラン一覧に戻る
+            </a>
+        </div>
+    </div>
+</div>
+@endsection

--- a/hotel-reservation/src/resources/views/user/contact/confirm.blade.php
+++ b/hotel-reservation/src/resources/views/user/contact/confirm.blade.php
@@ -1,0 +1,44 @@
+@extends('layouts.app')
+
+@section('title', 'お問い合わせ内容の確認')
+
+@section('content')
+<div class="container py-5">
+    <h1 class="h3 mb-2">お問い合わせ内容の確認</h1>
+    <p class="text-muted mb-4">以下の内容でお問い合わせを送信します。よろしければ「送信する」ボタンを押してください。</p>
+
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body p-4">
+                    <table class="table table-bordered mb-0">
+                        <tr><th class="table-light" style="width:9em;">姓名</th><td>{{ $validated['last_name'] }} {{ $validated['first_name'] }}</td></tr>
+                        <tr><th class="table-light">メールアドレス</th><td>{{ $validated['email'] }}</td></tr>
+                        <tr><th class="table-light">住所</th><td>{{ $validated['address'] }}</td></tr>
+                        <tr><th class="table-light">電話番号</th><td>{{ $validated['phone'] }}</td></tr>
+                        <tr><th class="table-light">お問い合わせ内容</th><td>{{ $validated['message'] ?? '—' }}</td></tr>
+                    </table>
+                </div>
+            </div>
+
+            <form action="{{ route('user.contact.store') }}" method="POST">
+                @csrf
+                @foreach ($validated as $key => $value)
+                    @if ($value !== null)
+                        <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    @endif
+                @endforeach
+
+                <div class="d-flex gap-2">
+                    <a href="{{ route('user.contact.create') }}" class="btn btn-outline-secondary flex-fill">
+                        戻って修正する
+                    </a>
+                    <button type="submit" class="btn btn-primary flex-fill">
+                        送信する
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/hotel-reservation/src/resources/views/user/contact/create.blade.php
+++ b/hotel-reservation/src/resources/views/user/contact/create.blade.php
@@ -1,0 +1,76 @@
+@extends('layouts.app')
+
+@section('title', 'お問い合わせ')
+
+@section('content')
+<div class="container py-5">
+    <h1 class="h3 mb-4">お問い合わせ</h1>
+
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <form method="POST" action="{{ route('user.contact.store') }}" novalidate>
+                @csrf
+
+                <div class="mb-3 row">
+                    <div class="col-6">
+                        <label for="last_name" class="form-label">姓 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control @error('last_name') is-invalid @enderror"
+                               id="last_name" name="last_name" value="{{ old('last_name') }}" required>
+                        @error('last_name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div class="col-6">
+                        <label for="first_name" class="form-label">名 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control @error('first_name') is-invalid @enderror"
+                               id="first_name" name="first_name" value="{{ old('first_name') }}" required>
+                        @error('first_name')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label for="email" class="form-label">メールアドレス <span class="text-danger">*</span></label>
+                    <input type="email" class="form-control @error('email') is-invalid @enderror"
+                           id="email" name="email" value="{{ old('email') }}" required>
+                    @error('email')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="mb-3">
+                    <label for="address" class="form-label">住所 <span class="text-danger">*</span></label>
+                    <input type="text" class="form-control @error('address') is-invalid @enderror"
+                           id="address" name="address" value="{{ old('address') }}" required>
+                    @error('address')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="mb-3">
+                    <label for="phone" class="form-label">電話番号 <span class="text-danger">*</span></label>
+                    <input type="tel" class="form-control @error('phone') is-invalid @enderror"
+                           id="phone" name="phone" value="{{ old('phone') }}" required>
+                    @error('phone')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="message" class="form-label">お問い合わせ内容</label>
+                    <textarea class="form-control @error('message') is-invalid @enderror"
+                              id="message" name="message" rows="5">{{ old('message') }}</textarea>
+                    @error('message')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="d-grid">
+                    <button type="submit" class="btn btn-primary btn-lg">送信する</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/hotel-reservation/src/resources/views/user/contact/create.blade.php
+++ b/hotel-reservation/src/resources/views/user/contact/create.blade.php
@@ -8,7 +8,7 @@
 
     <div class="row justify-content-center">
         <div class="col-lg-8">
-            <form method="POST" action="{{ route('user.contact.store') }}" novalidate>
+            <form method="POST" action="{{ route('user.contact.confirm') }}" novalidate>
                 @csrf
 
                 <div class="mb-3 row">

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservati
 use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
 use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
 use App\Http\Controllers\User\Contact\CompleteController as UserContactCompleteController;
+use App\Http\Controllers\User\Contact\ConfirmController as UserContactConfirmController;
 use App\Http\Controllers\User\Contact\CreateController as UserContactCreateController;
 use App\Http\Controllers\User\Contact\StoreController as UserContactStoreController;
 use App\Http\Controllers\User\Plan\CalendarController as UserPlanCalendarController;
@@ -36,6 +37,7 @@ Route::get('rooms', fn () => view('user.rooms'))->name('user.rooms');
 // 宿泊者：お問い合わせ
 Route::prefix('contact')->name('user.contact.')->group(function () {
     Route::get('/', UserContactCreateController::class)->name('create');
+    Route::post('confirm', UserContactConfirmController::class)->name('confirm');
     Route::post('/', UserContactStoreController::class)->name('store');
     Route::get('complete', UserContactCompleteController::class)->name('complete');
 });

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -15,6 +15,9 @@ use App\Http\Controllers\Admin\ReservationSlot\EditController as AdminReservatio
 use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservationSlotIndexController;
 use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
 use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
+use App\Http\Controllers\User\Contact\CompleteController as UserContactCompleteController;
+use App\Http\Controllers\User\Contact\CreateController as UserContactCreateController;
+use App\Http\Controllers\User\Contact\StoreController as UserContactStoreController;
 use App\Http\Controllers\User\Plan\CalendarController as UserPlanCalendarController;
 use App\Http\Controllers\User\Plan\IndexController as UserPlanIndexController;
 use App\Http\Controllers\User\Plan\ShowController as UserPlanShowController;
@@ -29,6 +32,13 @@ Route::get('/', function () {
 
 Route::get('access', fn () => view('user.access'))->name('user.access');
 Route::get('rooms', fn () => view('user.rooms'))->name('user.rooms');
+
+// 宿泊者：お問い合わせ
+Route::prefix('contact')->name('user.contact.')->group(function () {
+    Route::get('/', UserContactCreateController::class)->name('create');
+    Route::post('/', UserContactStoreController::class)->name('store');
+    Route::get('complete', UserContactCompleteController::class)->name('complete');
+});
 
 // 宿泊者：プラン閲覧（認証不要）
 Route::prefix('plans')->name('user.plans.')->group(function () {

--- a/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
@@ -25,6 +25,24 @@ class ContactControllerTest extends TestCase
     }
 
     // ----------------------------------------------------------------
+    // ConfirmController
+    // ----------------------------------------------------------------
+
+    public function test_正常な入力でお問い合わせ確認画面が表示される(): void
+    {
+        $this->post(route('user.contact.confirm'), $this->postData())
+            ->assertOk()
+            ->assertSee('田中')
+            ->assertSee('hanako@example.com');
+    }
+
+    public function test_バリデーションエラー時は確認画面に進めない(): void
+    {
+        $this->post(route('user.contact.confirm'), [])
+            ->assertSessionHasErrors(['last_name', 'first_name', 'email', 'address', 'phone']);
+    }
+
+    // ----------------------------------------------------------------
     // StoreController
     // ----------------------------------------------------------------
 

--- a/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\User\Contact;
+
+use App\Mail\InquiryCompletedMail;
+use App\Mail\InquiryReceivedMail;
+use App\Models\Admin;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ContactControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ----------------------------------------------------------------
+    // CreateController
+    // ----------------------------------------------------------------
+
+    public function test_お問い合わせフォームが表示される(): void
+    {
+        $this->get(route('user.contact.create'))
+            ->assertOk();
+    }
+
+    // ----------------------------------------------------------------
+    // StoreController
+    // ----------------------------------------------------------------
+
+    public function test_正常な入力でお問い合わせが保存される(): void
+    {
+        $this->post(route('user.contact.store'), $this->postData())
+            ->assertRedirect(route('user.contact.complete'));
+
+        $this->assertDatabaseHas('inquiries', [
+            'last_name' => '田中',
+            'email'     => 'hanako@example.com',
+        ]);
+    }
+
+    public function test_バリデーションエラー時はお問い合わせが保存されない(): void
+    {
+        $this->post(route('user.contact.store'), [])
+            ->assertSessionHasErrors(['last_name', 'first_name', 'email', 'address', 'phone']);
+
+        $this->assertDatabaseCount('inquiries', 0);
+    }
+
+    public function test_送信後に管理者へお問い合わせ受信メールが送信される(): void
+    {
+        Mail::fake();
+        Admin::create([
+            'last_name'  => '管理',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+
+        $this->post(route('user.contact.store'), $this->postData());
+
+        Mail::assertSent(InquiryReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
+    }
+
+    public function test_送信後に宿泊者へお問い合わせ完了メールが送信される(): void
+    {
+        Mail::fake();
+
+        $this->post(route('user.contact.store'), $this->postData());
+
+        Mail::assertSent(InquiryCompletedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
+    }
+
+    // ----------------------------------------------------------------
+    // CompleteController
+    // ----------------------------------------------------------------
+
+    public function test_お問い合わせ完了ページが表示される(): void
+    {
+        $this->get(route('user.contact.complete'))
+            ->assertOk();
+    }
+
+    // ----------------------------------------------------------------
+    // ヘルパー
+    // ----------------------------------------------------------------
+
+    /** @return array<string, mixed> */
+    private function postData(): array
+    {
+        return [
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'hanako@example.com',
+            'address'    => '大阪府大阪市1-1-1',
+            'phone'      => '0612345678',
+            'message'    => 'テストのお問い合わせです。',
+        ];
+    }
+}

--- a/hotel-reservation/src/tests/Unit/Mail/InquiryCompletedMailTest.php
+++ b/hotel-reservation/src/tests/Unit/Mail/InquiryCompletedMailTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\InquiryCompletedMail;
+use App\Models\Inquiry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InquiryCompletedMailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Inquiry $inquiry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->inquiry = Inquiry::factory()->create([
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'guest@example.com',
+            'message'    => 'テストの問い合わせです。',
+        ]);
+    }
+
+    public function test_件名がお問い合わせありがとうございますである(): void
+    {
+        $mail = new InquiryCompletedMail($this->inquiry);
+        $mail->assertHasSubject('お問い合わせありがとうございます');
+    }
+
+    public function test_宛先がお問い合わせ者のメールアドレスである(): void
+    {
+        $mail = new InquiryCompletedMail($this->inquiry);
+        $mail->assertHasTo('guest@example.com');
+    }
+
+    public function test_本文にお問い合わせ者の氏名が含まれる(): void
+    {
+        $mail = new InquiryCompletedMail($this->inquiry);
+        $mail->assertSeeInHtml('田中');
+        $mail->assertSeeInHtml('花子');
+    }
+}

--- a/hotel-reservation/src/tests/Unit/Mail/InquiryReceivedMailTest.php
+++ b/hotel-reservation/src/tests/Unit/Mail/InquiryReceivedMailTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Mail;
+
+use App\Mail\InquiryReceivedMail;
+use App\Models\Inquiry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InquiryReceivedMailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Inquiry $inquiry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->inquiry = Inquiry::factory()->create([
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'guest@example.com',
+            'message'    => 'テストの問い合わせです。',
+        ]);
+    }
+
+    public function test_件名がお問い合わせを受け付けましたである(): void
+    {
+        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
+        $mail->assertHasSubject('お問い合わせを受け付けました');
+    }
+
+    public function test_宛先が指定した管理者メールアドレスである(): void
+    {
+        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
+        $mail->assertHasTo('admin@example.com');
+    }
+
+    public function test_本文にお問い合わせ者の氏名が含まれる(): void
+    {
+        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
+        $mail->assertSeeInHtml('田中');
+        $mail->assertSeeInHtml('花子');
+    }
+}


### PR DESCRIPTION
## Summary

- `InquiryStatus` Enum に `label()` メソッドを追加
- `InquiryReceivedMail`（管理者向け）・`InquiryCompletedMail`（宿泊者向け）を追加
- `User/Contact/CreateController`・`StoreController`・`CompleteController` を追加
- お問い合わせルート（`GET /contact`, `POST /contact`, `GET /contact/complete`）を追加
- お問い合わせフォーム・完了ページのビューを追加（Bootstrap）
- お問い合わせフォーム送信前に確認画面を挟む（create → confirm → store）
- layouts/app.blade.php のお問い合わせリンクを route('user.contact.create') に修正

## Test plan

- [x] `ContactControllerTest` Feature テスト（6件）green
- [x] `InquiryReceivedMailTest` / `InquiryCompletedMailTest` Unit テスト（各3件）green
- [x] 全テスト 135 件 green
- [x] Larastan level 6 / PHP CS Fixer 通過
