### PR TITLE
feat: 管理者側お問い合わせ管理機能の実装 (#100)

### DIFF
--- a/hotel-reservation/src/app/Enums/InquiryStatus.php
+++ b/hotel-reservation/src/app/Enums/InquiryStatus.php
@@ -4,14 +4,16 @@ namespace App\Enums;
 
 enum InquiryStatus: int
 {
-    case Unread = 1;
-    case Read   = 2;
+    case Pending    = 1;
+    case InProgress = 2;
+    case Resolved   = 3;
 
     public function label(): string
     {
         return match ($this) {
-            self::Unread => '問い合わせ中',
-            self::Read   => '完了',
+            self::Pending    => '未対応',
+            self::InProgress => '対応中',
+            self::Resolved   => '対応完了',
         };
     }
 }

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/IndexController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Inquiry;
+
+use App\Http\Controllers\Controller;
+use App\Models\Inquiry;
+use Illuminate\View\View;
+
+class IndexController extends Controller
+{
+    public function __invoke(): View
+    {
+        $inquiries = Inquiry::latest()->paginate(20);
+
+        return view('admin.inquiry.index', compact('inquiries'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/ShowController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/ShowController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Inquiry;
+
+use App\Http\Controllers\Controller;
+use App\Models\Inquiry;
+use Illuminate\View\View;
+
+class ShowController extends Controller
+{
+    public function __invoke(Inquiry $inquiry): View
+    {
+        return view('admin.inquiry.show', compact('inquiry'));
+    }
+}

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/UpdateController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Admin\Inquiry;
+
+use App\Enums\InquiryStatus;
+use App\Http\Controllers\Controller;
+use App\Models\Inquiry;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class UpdateController extends Controller
+{
+    public function __invoke(Request $request, Inquiry $inquiry): RedirectResponse
+    {
+        $validated = $request->validate([
+            'status' => ['required', 'integer', 'in:' . implode(',', array_column(InquiryStatus::cases(), 'value'))],
+        ]);
+
+        $inquiry->update(['status' => $validated['status']]);
+
+        return redirect()->route('admin.inquiries.show', $inquiry);
+    }
+}

--- a/hotel-reservation/src/database/factories/InquiryFactory.php
+++ b/hotel-reservation/src/database/factories/InquiryFactory.php
@@ -25,7 +25,7 @@ class InquiryFactory extends Factory
             'address' => $this->faker->address(),
             'phone' => $this->faker->phoneNumber(),
             'message' => $this->faker->optional()->sentence(),
-            'status' => InquiryStatus::Unread,
+            'status' => InquiryStatus::Pending,
         ];
     }
 }

--- a/hotel-reservation/src/resources/views/admin/inquiry/index.blade.php
+++ b/hotel-reservation/src/resources/views/admin/inquiry/index.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.admin')
+
+@section('title', 'お問い合わせ管理')
+
+@section('content')
+<div class="container">
+
+    <h1 class="h4 fw-bold mb-4">お問い合わせ管理</h1>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>ID</th>
+                            <th>氏名</th>
+                            <th>メールアドレス</th>
+                            <th>受付日時</th>
+                            <th>ステータス</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($inquiries as $inquiry)
+                            <tr>
+                                <td class="text-muted small">{{ $inquiry->id }}</td>
+                                <td>{{ $inquiry->last_name }} {{ $inquiry->first_name }}</td>
+                                <td>{{ $inquiry->email }}</td>
+                                <td class="small text-muted">{{ $inquiry->created_at->format('Y/m/d H:i') }}</td>
+                                <td>
+                                    @if ($inquiry->status === \App\Enums\InquiryStatus::Pending)
+                                        <span class="badge bg-danger">{{ $inquiry->status->label() }}</span>
+                                    @elseif ($inquiry->status === \App\Enums\InquiryStatus::InProgress)
+                                        <span class="badge bg-warning text-dark">{{ $inquiry->status->label() }}</span>
+                                    @else
+                                        <span class="badge bg-success">{{ $inquiry->status->label() }}</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    <a href="{{ route('admin.inquiries.show', $inquiry) }}"
+                                       class="btn btn-sm btn-outline-primary">詳細</a>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">お問い合わせはありません</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        {{ $inquiries->links() }}
+    </div>
+
+</div>
+@endsection

--- a/hotel-reservation/src/resources/views/admin/inquiry/show.blade.php
+++ b/hotel-reservation/src/resources/views/admin/inquiry/show.blade.php
@@ -1,0 +1,77 @@
+@extends('layouts.admin')
+
+@section('title', 'お問い合わせ詳細')
+
+@section('content')
+<div class="container">
+
+    <div class="d-flex align-items-center gap-3 mb-4">
+        <a href="{{ route('admin.inquiries.index') }}" class="btn btn-outline-secondary btn-sm">← 一覧に戻る</a>
+        <h1 class="h4 fw-bold mb-0">お問い合わせ詳細</h1>
+    </div>
+
+    @if (session('success'))
+        <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
+            {{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="閉じる"></button>
+        </div>
+    @endif
+
+    <div class="card shadow-sm border-0 mb-4">
+        <div class="card-body p-4">
+            <table class="table table-bordered mb-0">
+                <tr>
+                    <th class="table-light" style="width:10em;">氏名</th>
+                    <td>{{ $inquiry->last_name }} {{ $inquiry->first_name }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">メールアドレス</th>
+                    <td>{{ $inquiry->email }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">住所</th>
+                    <td>{{ $inquiry->address }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">電話番号</th>
+                    <td>{{ $inquiry->phone }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">お問い合わせ内容</th>
+                    <td>{{ $inquiry->message ?? '—' }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">受付日時</th>
+                    <td>{{ $inquiry->created_at->format('Y/m/d H:i') }}</td>
+                </tr>
+                <tr>
+                    <th class="table-light">ステータス</th>
+                    <td>
+                        @if ($inquiry->status === \App\Enums\InquiryStatus::Pending)
+                            <span class="badge bg-danger">{{ $inquiry->status->label() }}</span>
+                        @elseif ($inquiry->status === \App\Enums\InquiryStatus::InProgress)
+                            <span class="badge bg-warning text-dark">{{ $inquiry->status->label() }}</span>
+                        @else
+                            <span class="badge bg-success">{{ $inquiry->status->label() }}</span>
+                        @endif
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </div>
+
+    <form action="{{ route('admin.inquiries.update', $inquiry) }}" method="POST" class="d-flex gap-2 flex-wrap">
+        @csrf
+        @method('PUT')
+        @foreach (\App\Enums\InquiryStatus::cases() as $status)
+            @if ($status !== $inquiry->status)
+                <button type="submit" name="status" value="{{ $status->value }}"
+                        class="btn {{ $status === \App\Enums\InquiryStatus::Resolved ? 'btn-success' : ($status === \App\Enums\InquiryStatus::InProgress ? 'btn-warning' : 'btn-outline-secondary') }}">
+                    {{ $status->label() }}にする
+                </button>
+            @endif
+        @endforeach
+    </form>
+
+</div>
+@endsection

--- a/hotel-reservation/src/resources/views/layouts/admin-nav.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin-nav.blade.php
@@ -17,5 +17,6 @@
 
     <div class="text-white-50 small px-3 pt-3 pb-1 text-uppercase" style="font-size:.7rem; letter-spacing:.08em;">その他</div>
 
-    <span class="nav-link rounded mb-1 text-white-50">お問い合わせ一覧</span>
+    <a class="nav-link rounded mb-1 {{ request()->routeIs('admin.inquiries.*') ? 'bg-secondary' : 'text-white-50' }} text-white"
+       href="{{ route('admin.inquiries.index') }}">お問い合わせ一覧</a>
 </nav>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -2,6 +2,9 @@
 
 use App\Http\Controllers\Admin\Auth\LoginController;
 use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\Inquiry\IndexController as AdminInquiryIndexController;
+use App\Http\Controllers\Admin\Inquiry\ShowController as AdminInquiryShowController;
+use App\Http\Controllers\Admin\Inquiry\UpdateController as AdminInquiryUpdateController;
 use App\Http\Controllers\Admin\Plan\DestroyController as AdminPlanDestroyController;
 use App\Http\Controllers\Admin\Plan\EditController as AdminPlanEditController;
 use App\Http\Controllers\Admin\Plan\IndexController as AdminPlanIndexController;
@@ -93,6 +96,13 @@ Route::prefix('admin')->name('admin.')->group(function () {
             Route::get('{reservationSlot}/edit', AdminReservationSlotEditController::class)->name('edit');
             Route::put('{reservationSlot}', AdminReservationSlotUpdateController::class)->name('update');
             Route::delete('{reservationSlot}', AdminReservationSlotDestroyController::class)->name('destroy');
+        });
+
+        // お問い合わせ管理
+        Route::prefix('inquiries')->name('inquiries.')->group(function () {
+            Route::get('/', AdminInquiryIndexController::class)->name('index');
+            Route::get('{inquiry}', AdminInquiryShowController::class)->name('show');
+            Route::put('{inquiry}', AdminInquiryUpdateController::class)->name('update');
         });
     });
 });

--- a/hotel-reservation/src/tests/Feature/Admin/Inquiry/InquiryControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Inquiry/InquiryControllerTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature\Admin\Inquiry;
+
+use App\Enums\InquiryStatus;
+use App\Models\Admin;
+use App\Models\Inquiry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class InquiryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Admin $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = Admin::create([
+            'last_name'  => '山田',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+    }
+
+    // ----------------------------------------------------------------
+    // 未認証チェック
+    // ----------------------------------------------------------------
+
+    public function test_未認証ユーザーは一覧にアクセスできない(): void
+    {
+        $this->get(route('admin.inquiries.index'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーは詳細にアクセスできない(): void
+    {
+        $inquiry = Inquiry::factory()->create();
+
+        $this->get(route('admin.inquiries.show', $inquiry))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_未認証ユーザーはステータス更新できない(): void
+    {
+        $inquiry = Inquiry::factory()->create();
+
+        $this->put(route('admin.inquiries.update', $inquiry), ['status' => InquiryStatus::InProgress->value])
+            ->assertRedirect(route('admin.login'));
+    }
+
+    // ----------------------------------------------------------------
+    // IndexController
+    // ----------------------------------------------------------------
+
+    public function test_一覧ページが表示される(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.inquiries.index'))
+            ->assertOk();
+    }
+
+    public function test_お問い合わせ一覧が表示される(): void
+    {
+        $inquiry = Inquiry::factory()->create([
+            'last_name'  => '鈴木',
+            'first_name' => '花子',
+            'email'      => 'hanako@example.com',
+        ]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.inquiries.index'))
+            ->assertSee('鈴木')
+            ->assertSee('花子')
+            ->assertSee('hanako@example.com');
+    }
+
+    public function test_一覧にステータスが日本語で表示される(): void
+    {
+        Inquiry::factory()->create(['status' => InquiryStatus::Pending]);
+        Inquiry::factory()->create(['status' => InquiryStatus::InProgress]);
+        Inquiry::factory()->create(['status' => InquiryStatus::Resolved]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.inquiries.index'))
+            ->assertSee('未対応')
+            ->assertSee('対応中')
+            ->assertSee('対応完了');
+    }
+
+    // ----------------------------------------------------------------
+    // ShowController
+    // ----------------------------------------------------------------
+
+    public function test_詳細ページが表示される(): void
+    {
+        $inquiry = Inquiry::factory()->create([
+            'last_name'  => '田中',
+            'first_name' => '一郎',
+            'message'    => 'テストメッセージ',
+        ]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->get(route('admin.inquiries.show', $inquiry))
+            ->assertOk()
+            ->assertSee('田中')
+            ->assertSee('一郎')
+            ->assertSee('テストメッセージ');
+    }
+
+    // ----------------------------------------------------------------
+    // UpdateController (ステータス変更)
+    // ----------------------------------------------------------------
+
+    public function test_ステータスを対応中に更新できる(): void
+    {
+        $inquiry = Inquiry::factory()->create(['status' => InquiryStatus::Pending]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.inquiries.update', $inquiry), ['status' => InquiryStatus::InProgress->value])
+            ->assertRedirect(route('admin.inquiries.show', $inquiry));
+
+        $this->assertDatabaseHas('inquiries', [
+            'id'     => $inquiry->id,
+            'status' => InquiryStatus::InProgress->value,
+        ]);
+    }
+
+    public function test_ステータスを対応完了に更新できる(): void
+    {
+        $inquiry = Inquiry::factory()->create(['status' => InquiryStatus::InProgress]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.inquiries.update', $inquiry), ['status' => InquiryStatus::Resolved->value])
+            ->assertRedirect(route('admin.inquiries.show', $inquiry));
+
+        $this->assertDatabaseHas('inquiries', [
+            'id'     => $inquiry->id,
+            'status' => InquiryStatus::Resolved->value,
+        ]);
+    }
+
+    public function test_ステータスを未対応に戻せる(): void
+    {
+        $inquiry = Inquiry::factory()->create(['status' => InquiryStatus::Resolved]);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.inquiries.update', $inquiry), ['status' => InquiryStatus::Pending->value])
+            ->assertRedirect(route('admin.inquiries.show', $inquiry));
+
+        $this->assertDatabaseHas('inquiries', [
+            'id'     => $inquiry->id,
+            'status' => InquiryStatus::Pending->value,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- お問い合わせ一覧・詳細ページを追加
- ステータスを 未対応 / 対応中 / 対応完了 の 3 段階に定義（`InquiryStatus` enum 変更）
- 詳細画面からワンクリックでステータス変更可能
- admin-nav のお問い合わせ一覧リンクを実ルートへ接続
- TDD: `InquiryControllerTest` 10 件追加（未認証チェック・一覧・詳細・ステータス更新）

## Test plan
- [x] `./vendor/bin/sail artisan test` が 147 passed であること
- [x] 管理者ログイン後、サイドバーの「お問い合わせ一覧」から遷移できること
- [x] 詳細画面でステータスボタンを押すと更新されること