### PR TITLE
feat: 予約リマインドバッチの実装 (#101)

### DIFF
--- a/hotel-reservation/src/app/Console/Commands/SendReservationReminders.php
+++ b/hotel-reservation/src/app/Console/Commands/SendReservationReminders.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\ReservationStatus;
+use App\Mail\ReservationReminderMail;
+use App\Models\Reservation;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendReservationReminders extends Command
+{
+    protected $signature = 'reservations:send-reminders';
+
+    protected $description = '翌日チェックイン予定の宿泊者にリマインドメールを送信する';
+
+    public function handle(): int
+    {
+        $tomorrow = now()->addDay()->toDateString();
+
+        $reservations = Reservation::query()
+            ->where('status', ReservationStatus::Confirmed)
+            ->whereHas('reservationSlot', fn ($q) => $q->whereDate('start', $tomorrow))
+            ->with('reservationSlot')
+            ->get();
+
+        foreach ($reservations as $reservation) {
+            Mail::send(new ReservationReminderMail($reservation));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/hotel-reservation/src/app/Mail/ReservationReminderMail.php
+++ b/hotel-reservation/src/app/Mail/ReservationReminderMail.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Reservation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ReservationReminderMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly Reservation $reservation)
+    {
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            to:      [$this->reservation->email],
+            subject: '【リマインド】明日のご宿泊について',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.reservation.reminder',
+        );
+    }
+}

--- a/hotel-reservation/src/resources/views/mail/reservation/reminder.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/reminder.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>【リマインド】明日のご宿泊について</title>
+</head>
+<body>
+    <p>{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
+
+    <p>明日のご宿泊日が近づきましたのでご連絡いたします。<br>
+    以下の内容でご予約をお受けしております。</p>
+
+    <table>
+        <tr>
+            <th>プラン名</th>
+            <td>{{ $reservation->plan_name }}</td>
+        </tr>
+        <tr>
+            <th>チェックイン</th>
+            <td>{{ $reservation->reservationSlot->start->format('Y年m月d日') }}</td>
+        </tr>
+        <tr>
+            <th>チェックアウト</th>
+            <td>{{ $reservation->reservationSlot->end->format('Y年m月d日') }}</td>
+        </tr>
+        <tr>
+            <th>料金</th>
+            <td>{{ number_format($reservation->price) }} 円</td>
+        </tr>
+    </table>
+
+    <p>ご不明な点がございましたら、お気軽にお問い合わせください。<br>
+    ご来館を心よりお待ちしております。</p>
+
+    <p>{{ config('app.name') }}</p>
+</body>
+</html>

--- a/hotel-reservation/src/routes/console.php
+++ b/hotel-reservation/src/routes/console.php
@@ -1,8 +1,12 @@
 <?php
 
+use App\Console\Commands\SendReservationReminders;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command(SendReservationReminders::class)->dailyAt('10:00');

--- a/hotel-reservation/src/tests/Feature/Console/SendReservationRemindersTest.php
+++ b/hotel-reservation/src/tests/Feature/Console/SendReservationRemindersTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Enums\ReservationStatus;
+use App\Mail\ReservationReminderMail;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class SendReservationRemindersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_翌日チェックインの確定予約にリマインドメールが送信される(): void
+    {
+        Mail::fake();
+
+        $tomorrow = now()->addDay()->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $tomorrow]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Confirmed,
+            'email'               => 'guest@example.com',
+        ]);
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertSent(ReservationReminderMail::class, 1);
+        Mail::assertSent(ReservationReminderMail::class, fn ($mail) => $mail->hasTo('guest@example.com'));
+    }
+
+    public function test_翌日以外のチェックインにはメールを送らない(): void
+    {
+        Mail::fake();
+
+        $dayAfterTomorrow = now()->addDays(2)->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $dayAfterTomorrow]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Confirmed,
+        ]);
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_キャンセル済み予約にはメールを送らない(): void
+    {
+        Mail::fake();
+
+        $tomorrow = now()->addDay()->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $tomorrow]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Cancelled,
+        ]);
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_複数の翌日予約に一括送信される(): void
+    {
+        Mail::fake();
+
+        $tomorrow = now()->addDay()->toDateString();
+        $slots = ReservationSlot::factory()->count(3)->create(['start' => $tomorrow]);
+        foreach ($slots as $slot) {
+            Reservation::factory()->create([
+                'reservation_slot_id' => $slot->id,
+                'status'              => ReservationStatus::Confirmed,
+            ]);
+        }
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertSent(ReservationReminderMail::class, 3);
+    }
+
+    public function test_翌日チェックインの対象予約が0件の場合は正常終了する(): void
+    {
+        Mail::fake();
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_送信されるメールに正しい予約者情報が含まれる(): void
+    {
+        Mail::fake();
+
+        $tomorrow = now()->addDay()->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $tomorrow]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Confirmed,
+            'email'               => 'taro@example.com',
+            'last_name'           => '山田',
+            'first_name'          => '太郎',
+            'plan_name'           => '特別プラン',
+        ]);
+
+        $this->artisan('reservations:send-reminders')->assertSuccessful();
+
+        Mail::assertSent(ReservationReminderMail::class, function ($mail) {
+            return $mail->hasTo('taro@example.com')
+                && $mail->reservation->last_name === '山田'
+                && $mail->reservation->plan_name === '特別プラン';
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- `reservations:send-reminders` Artisan コマンドを追加
  - 翌日チェックイン予定の確定予約者にリマインドメールを送信
  - 対象ゼロ件でも正常終了（空振り処理）
- `ReservationReminderMail` を追加（件名: 【リマインド】明日のご宿泊について）
- `Schedule::command(...)->dailyAt('10:00')` でスケジュール登録
- TDD: 6件（対象あり・翌日以外・キャンセル済み・複数件・0件・内容確認）

## Test plan
- [x] 153 tests passed
- [x] ローカルで手動実行して Mailpit に翌日分のみ届くことを確認済み