### PR TITLE
fix: お問い合わせ確認画面の「戻って修正する」でフォームデータが消えるバグを修正 (#148)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/BackController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/BackController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\User\Contact;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class BackController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        return redirect()->route('user.contact.create')->withInput($request->all());
+    }
+}

--- a/hotel-reservation/src/resources/views/user/contact/confirm.blade.php
+++ b/hotel-reservation/src/resources/views/user/contact/confirm.blade.php
@@ -30,13 +30,22 @@
                 @endforeach
 
                 <div class="d-flex gap-2">
-                    <a href="{{ route('user.contact.create') }}" class="btn btn-outline-secondary flex-fill">
-                        戻って修正する
-                    </a>
                     <button type="submit" class="btn btn-primary flex-fill">
                         送信する
                     </button>
                 </div>
+            </form>
+
+            <form action="{{ route('user.contact.back') }}" method="POST" class="mt-2">
+                @csrf
+                @foreach ($validated as $key => $value)
+                    @if ($value !== null)
+                        <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                    @endif
+                @endforeach
+                <button type="submit" class="btn btn-outline-secondary w-100">
+                    戻って修正する
+                </button>
             </form>
         </div>
     </div>

--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Admin\ReservationSlot\EditController as AdminReservatio
 use App\Http\Controllers\Admin\ReservationSlot\IndexController as AdminReservationSlotIndexController;
 use App\Http\Controllers\Admin\ReservationSlot\StoreController as AdminReservationSlotStoreController;
 use App\Http\Controllers\Admin\ReservationSlot\UpdateController as AdminReservationSlotUpdateController;
+use App\Http\Controllers\User\Contact\BackController as UserContactBackController;
 use App\Http\Controllers\User\Contact\CompleteController as UserContactCompleteController;
 use App\Http\Controllers\User\Contact\ConfirmController as UserContactConfirmController;
 use App\Http\Controllers\User\Contact\CreateController as UserContactCreateController;
@@ -41,6 +42,7 @@ Route::get('rooms', fn () => view('user.rooms'))->name('user.rooms');
 Route::prefix('contact')->name('user.contact.')->group(function () {
     Route::get('/', UserContactCreateController::class)->name('create');
     Route::post('confirm', UserContactConfirmController::class)->name('confirm');
+    Route::post('back', UserContactBackController::class)->name('back');
     Route::post('/', UserContactStoreController::class)->name('store');
     Route::get('complete', UserContactCompleteController::class)->name('complete');
 });

--- a/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
@@ -90,6 +90,21 @@ class ContactControllerTest extends TestCase
     }
 
     // ----------------------------------------------------------------
+    // BackController
+    // ----------------------------------------------------------------
+
+    public function test_確認画面から戻るとフォームに入力値が復元される(): void
+    {
+        $this->post(route('user.contact.back'), $this->postData())
+            ->assertRedirect(route('user.contact.create'));
+
+        $this->get(route('user.contact.create'))
+            ->assertOk()
+            ->assertSee('田中')
+            ->assertSee('hanako@example.com');
+    }
+
+    // ----------------------------------------------------------------
     // CompleteController
     // ----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- 確認画面の「戻って修正する」が `<a href>` の GET リンクだったため、フォームデータが全て消えるバグを修正
- `BackController` を新設し、`withInput()` でフラッシュデータとして入力値を保持
- `confirm.blade.php` の `<a>` リンクを hidden フォーム POST に置き換え
- `POST /contact/back` → `user.contact.back` ルートを追加

## Test plan

- [x] `test_確認画面から戻るとフォームに入力値が復元される` がグリーン
- [x] `ContactControllerTest` 全9件グリーン
- [x] フルスイート 154件グリーン

Closes #148