### PR TITLE
feat: リマインドバッチに送信件数のログ出力を追加 (#149)

### DIFF
--- a/hotel-reservation/src/app/Console/Commands/SendReservationReminders.php
+++ b/hotel-reservation/src/app/Console/Commands/SendReservationReminders.php
@@ -28,6 +28,8 @@ class SendReservationReminders extends Command
             Mail::send(new ReservationReminderMail($reservation));
         }
 
+        $this->info("リマインドメールを {$reservations->count()} 件送信しました。");
+
         return self::SUCCESS;
     }
 }

--- a/hotel-reservation/src/tests/Feature/Console/SendReservationRemindersTest.php
+++ b/hotel-reservation/src/tests/Feature/Console/SendReservationRemindersTest.php
@@ -91,6 +91,33 @@ class SendReservationRemindersTest extends TestCase
         Mail::assertNothingSent();
     }
 
+    public function test_送信件数がコンソールに出力される(): void
+    {
+        Mail::fake();
+
+        $tomorrow = now()->addDay()->toDateString();
+        $slots = ReservationSlot::factory()->count(3)->create(['start' => $tomorrow]);
+        foreach ($slots as $slot) {
+            Reservation::factory()->create([
+                'reservation_slot_id' => $slot->id,
+                'status'              => ReservationStatus::Confirmed,
+            ]);
+        }
+
+        $this->artisan('reservations:send-reminders')
+            ->assertSuccessful()
+            ->expectsOutput('リマインドメールを 3 件送信しました。');
+    }
+
+    public function test_対象が0件の場合も件数がコンソールに出力される(): void
+    {
+        Mail::fake();
+
+        $this->artisan('reservations:send-reminders')
+            ->assertSuccessful()
+            ->expectsOutput('リマインドメールを 0 件送信しました。');
+    }
+
     public function test_送信されるメールに正しい予約者情報が含まれる(): void
     {
         Mail::fake();


### PR DESCRIPTION
## Summary

- `reservations:send-reminders` 実行後に `リマインドメールを X 件送信しました。` をコンソール出力
- 0件のときも出力されるため、cronログで正常実行を確認可能
- `expectsOutput()` を使ったテストを2件追加（送信3件・0件それぞれ）

## Test plan

- [x] `test_送信件数がコンソールに出力される` グリーン
- [x] `test_対象が0件の場合も件数がコンソールに出力される` グリーン
- [x] フルスイート 156件グリーン

Closes #149