### PR TITLE
feat: 管理者ダッシュボードの実装（サマリー統計・直近予約一覧） (#151)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/DashboardController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/DashboardController.php
@@ -2,13 +2,50 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\InquiryStatus;
+use App\Enums\ReservationStatus;
 use App\Http\Controllers\Controller;
+use App\Models\Inquiry;
+use App\Models\Reservation;
 use Illuminate\View\View;
 
 class DashboardController extends Controller
 {
     public function __invoke(): View
     {
-        return view('admin.dashboard');
+        $today    = now()->toDateString();
+        $tomorrow = now()->addDay()->toDateString();
+
+        $todayCount = Reservation::query()
+            ->where('status', ReservationStatus::Confirmed)
+            ->whereHas('reservationSlot', fn ($q) => $q->whereDate('start', $today))
+            ->count();
+
+        $tomorrowCount = Reservation::query()
+            ->where('status', ReservationStatus::Confirmed)
+            ->whereHas('reservationSlot', fn ($q) => $q->whereDate('start', $tomorrow))
+            ->count();
+
+        $pendingInquiryCount = Inquiry::where('status', InquiryStatus::Pending)->count();
+
+        $monthlyCount = Reservation::query()
+            ->where('status', ReservationStatus::Confirmed)
+            ->whereMonth('created_at', now()->month)
+            ->whereYear('created_at', now()->year)
+            ->count();
+
+        $recentReservations = Reservation::query()
+            ->with('reservationSlot')
+            ->latest()
+            ->limit(5)
+            ->get();
+
+        return view('admin.dashboard', compact(
+            'todayCount',
+            'tomorrowCount',
+            'pendingInquiryCount',
+            'monthlyCount',
+            'recentReservations',
+        ));
     }
 }

--- a/hotel-reservation/src/resources/views/admin/dashboard.blade.php
+++ b/hotel-reservation/src/resources/views/admin/dashboard.blade.php
@@ -3,8 +3,7 @@
 @section('title', 'ダッシュボード')
 
 @section('content')
-
-<div class="container">
+<div class="container-fluid">
     <div class="d-flex align-items-center justify-content-between mb-4">
         <h1 class="h4 fw-bold mb-0">ダッシュボード</h1>
         <span class="text-muted small">
@@ -12,6 +11,99 @@
         </span>
     </div>
 
+    {{-- サマリーカード --}}
+    <div class="row g-3 mb-4">
+        <div class="col-sm-6 col-xl-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="fs-2 text-primary">📅</div>
+                    <div>
+                        <div class="text-muted small">今日のチェックイン</div>
+                        <div class="fs-3 fw-bold">{{ $todayCount }}<span class="fs-6 fw-normal text-muted ms-1">件</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6 col-xl-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="fs-2 text-info">🌅</div>
+                    <div>
+                        <div class="text-muted small">明日のチェックイン</div>
+                        <div class="fs-3 fw-bold">{{ $tomorrowCount }}<span class="fs-6 fw-normal text-muted ms-1">件</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6 col-xl-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="fs-2 text-danger">✉️</div>
+                    <div>
+                        <div class="text-muted small">未対応のお問い合わせ</div>
+                        <div class="fs-3 fw-bold">{{ $pendingInquiryCount }}<span class="fs-6 fw-normal text-muted ms-1">件</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-sm-6 col-xl-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex align-items-center gap-3">
+                    <div class="fs-2 text-success">📊</div>
+                    <div>
+                        <div class="text-muted small">今月の予約件数</div>
+                        <div class="fs-3 fw-bold">{{ $monthlyCount }}<span class="fs-6 fw-normal text-muted ms-1">件</span></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- 直近の予約 --}}
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-header bg-white fw-bold border-bottom">直近の予約</div>
+        <div class="card-body p-0">
+            @if ($recentReservations->isEmpty())
+                <p class="text-muted text-center py-4 mb-0">予約はまだありません。</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>氏名</th>
+                                <th>プラン</th>
+                                <th>チェックイン</th>
+                                <th>料金</th>
+                                <th>ステータス</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($recentReservations as $reservation)
+                            <tr>
+                                <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
+                                <td>{{ $reservation->plan_name }}</td>
+                                <td>{{ $reservation->reservationSlot?->start?->format('Y/m/d') ?? '—' }}</td>
+                                <td>¥{{ number_format($reservation->price) }}</td>
+                                <td>
+                                    @if ($reservation->status === \App\Enums\ReservationStatus::Confirmed)
+                                        <span class="badge bg-success">確定</span>
+                                    @else
+                                        <span class="badge bg-secondary">キャンセル</span>
+                                    @endif
+                                </td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+        <div class="card-footer bg-white text-end">
+            <a href="{{ route('admin.reservations.index') }}" class="btn btn-sm btn-outline-secondary">すべての予約を見る</a>
+        </div>
+    </div>
+
+    {{-- ナビゲーションカード --}}
     <div class="row g-3">
         <div class="col-md-4">
             <a href="{{ route('admin.plans.index') }}" class="text-decoration-none">
@@ -48,5 +140,4 @@
         </div>
     </div>
 </div>
-
 @endsection

--- a/hotel-reservation/src/resources/views/layouts/admin.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/admin.blade.php
@@ -64,7 +64,7 @@
         </aside>
 
         {{-- ===== メインコンテンツ ===== --}}
-        <main class="flex-grow-1 p-4" style="margin-left:0;" id="adminMain">
+        <main class="flex-grow-1 p-4" id="adminMain">
             @yield('content')
         </main>
 

--- a/hotel-reservation/src/tests/Feature/Admin/DashboardControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/DashboardControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\InquiryStatus;
+use App\Enums\ReservationStatus;
+use App\Models\Admin;
+use App\Models\Inquiry;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class DashboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(): Admin
+    {
+        return Admin::create([
+            'last_name'  => '管理',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+    }
+
+    public function test_未認証ユーザーはダッシュボードにアクセスできない(): void
+    {
+        $this->get(route('admin.dashboard'))
+            ->assertRedirect(route('admin.login'));
+    }
+
+    public function test_ダッシュボードが表示される(): void
+    {
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertOk();
+    }
+
+    public function test_今日のチェックイン件数が表示される(): void
+    {
+        $today = now()->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $today]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Confirmed,
+        ]);
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertSee('1')
+            ->assertViewHas('todayCount', 1);
+    }
+
+    public function test_明日のチェックイン件数が表示される(): void
+    {
+        $tomorrow = now()->addDay()->toDateString();
+        $slot = ReservationSlot::factory()->create(['start' => $tomorrow]);
+        Reservation::factory()->create([
+            'reservation_slot_id' => $slot->id,
+            'status'              => ReservationStatus::Confirmed,
+        ]);
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertViewHas('tomorrowCount', 1);
+    }
+
+    public function test_未対応のお問い合わせ件数が表示される(): void
+    {
+        Inquiry::factory()->count(2)->create(['status' => InquiryStatus::Pending]);
+        Inquiry::factory()->create(['status' => InquiryStatus::Resolved]);
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertViewHas('pendingInquiryCount', 2);
+    }
+
+    public function test_今月の予約件数が表示される(): void
+    {
+        Reservation::factory()->count(3)->create(['status' => ReservationStatus::Confirmed]);
+        Reservation::factory()->create(['status' => ReservationStatus::Cancelled]);
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertViewHas('monthlyCount', 3);
+    }
+
+    public function test_直近5件の予約が表示される(): void
+    {
+        Reservation::factory()->count(7)->create(['status' => ReservationStatus::Confirmed]);
+
+        $this->actingAs($this->admin(), 'admin')
+            ->get(route('admin.dashboard'))
+            ->assertViewHas('recentReservations', fn ($r) => $r->count() === 5);
+    }
+}


### PR DESCRIPTION
## Summary

- ダッシュボードにサマリーカード4枚を追加
  - 今日のチェックイン件数
  - 明日のチェックイン件数
  - 未対応のお問い合わせ件数
  - 今月の予約件数（確定のみ）
- 直近5件の予約テーブルを追加（氏名・プラン・チェックイン・料金・ステータス）
- ダッシュボード実装中に発見した管理者レイアウトのバグも同時修正
  - `<main>` のインラインスタイル `margin-left:0` が `@media` クエリを上書きしており、全管理者ページでサイドバーとコンテンツが重なっていた

## Test plan

- [x] `DashboardControllerTest` 7件グリーン
- [x] フルスイート 163件グリーン
- [x] ブラウザでダッシュボードのサマリー・テーブル表示を確認
- [x] ブラウザでサイドバーとのレイアウト崩れがないことを確認（ダッシュボード・他管理者ページ）

Closes #151