### PR TITLE
feat: メールテンプレートにスタイルを適用 (#150)

### DIFF
--- a/hotel-reservation/src/resources/views/layouts/mail.blade.php
+++ b/hotel-reservation/src/resources/views/layouts/mail.blade.php
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title')</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f4f4f4; font-family:'Helvetica Neue', Arial, sans-serif; color:#333333;">
+
+    <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4; padding:32px 0;">
+        <tr>
+            <td align="center">
+                <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px; width:100%; background-color:#ffffff; border-radius:8px; overflow:hidden; box-shadow:0 2px 8px rgba(0,0,0,0.08);">
+
+                    {{-- ヘッダー --}}
+                    <tr>
+                        <td style="background-color:#1a1a2e; padding:24px 32px; text-align:center;">
+                            <p style="margin:0; color:#ffffff; font-size:20px; font-weight:bold; letter-spacing:0.05em;">
+                                {{ config('app.name') }}
+                            </p>
+                        </td>
+                    </tr>
+
+                    {{-- 本文 --}}
+                    <tr>
+                        <td style="padding:32px;">
+                            @yield('content')
+                        </td>
+                    </tr>
+
+                    {{-- フッター --}}
+                    <tr>
+                        <td style="background-color:#f8f8f8; padding:16px 32px; text-align:center; border-top:1px solid #eeeeee;">
+                            <p style="margin:0; font-size:12px; color:#999999;">
+                                このメールは {{ config('app.name') }} より自動送信されています。
+                            </p>
+                        </td>
+                    </tr>
+
+                </table>
+            </td>
+        </tr>
+    </table>
+
+</body>
+</html>

--- a/hotel-reservation/src/resources/views/mail/inquiry/completed.blade.php
+++ b/hotel-reservation/src/resources/views/mail/inquiry/completed.blade.php
@@ -1,22 +1,19 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>お問い合わせありがとうございます</title>
-</head>
-<body>
-    <p>{{ $inquiry->last_name }} {{ $inquiry->first_name }} 様</p>
+@extends('layouts.mail')
 
-    <p>お問い合わせをいただきありがとうございます。<br>
-    内容を確認のうえ、担当者よりご連絡いたします。</p>
+@section('title', 'お問い合わせありがとうございます')
 
-    <table>
-        <tr>
-            <th>お問い合わせ内容</th>
-            <td>{{ $inquiry->message }}</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">{{ $inquiry->last_name }} {{ $inquiry->first_name }} 様</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    お問い合わせをいただきありがとうございます。<br>
+    内容を確認のうえ、担当者よりご連絡いたします。
+</p>
+
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">お問い合わせ内容</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->message }}</td>
+    </tr>
+</table>
+@endsection

--- a/hotel-reservation/src/resources/views/mail/inquiry/received.blade.php
+++ b/hotel-reservation/src/resources/views/mail/inquiry/received.blade.php
@@ -1,37 +1,34 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>お問い合わせを受け付けました</title>
-</head>
-<body>
-    <p>管理者様</p>
+@extends('layouts.mail')
 
-    <p>新しいお問い合わせを受け付けました。</p>
+@section('title', 'お問い合わせを受け付けました')
 
-    <table>
-        <tr>
-            <th>お名前</th>
-            <td>{{ $inquiry->last_name }} {{ $inquiry->first_name }}</td>
-        </tr>
-        <tr>
-            <th>メールアドレス</th>
-            <td>{{ $inquiry->email }}</td>
-        </tr>
-        <tr>
-            <th>住所</th>
-            <td>{{ $inquiry->address }}</td>
-        </tr>
-        <tr>
-            <th>電話番号</th>
-            <td>{{ $inquiry->phone }}</td>
-        </tr>
-        <tr>
-            <th>お問い合わせ内容</th>
-            <td>{{ $inquiry->message }}</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">管理者様</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    新しいお問い合わせを受け付けました。
+</p>
+
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">お名前</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->last_name }} {{ $inquiry->first_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">メールアドレス</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->email }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">住所</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->address }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">電話番号</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->phone }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">お問い合わせ内容</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $inquiry->message }}</td>
+    </tr>
+</table>
+@endsection

--- a/hotel-reservation/src/resources/views/mail/reservation/cancelled.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/cancelled.blade.php
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約キャンセルのお知らせ</title>
-</head>
-<body>
-    <p>{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
+@extends('layouts.mail')
 
-    <p>以下の予約をキャンセルいたしました。</p>
+@section('title', '予約キャンセルのお知らせ')
 
-    <table>
-        <tr>
-            <th>プラン名</th>
-            <td>{{ $reservation->plan_name }}</td>
-        </tr>
-        <tr>
-            <th>料金</th>
-            <td>{{ number_format($reservation->price) }} 円</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
 
-    <p>またのご利用をお待ちしております。</p>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    以下の予約をキャンセルいたしました。
+</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">プラン名</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->plan_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">料金</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ number_format($reservation->price) }} 円</td>
+    </tr>
+</table>
+
+<p style="margin:0; font-size:15px; line-height:1.7;">
+    またのご利用をお待ちしております。
+</p>
+@endsection

--- a/hotel-reservation/src/resources/views/mail/reservation/confirmed.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/confirmed.blade.php
@@ -1,29 +1,28 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約完了のお知らせ</title>
-</head>
-<body>
-    <p>{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
+@extends('layouts.mail')
 
-    <p>このたびはご予約いただきありがとうございます。<br>
-    以下の内容で予約を承りました。</p>
+@section('title', '予約完了のお知らせ')
 
-    <table>
-        <tr>
-            <th>プラン名</th>
-            <td>{{ $reservation->plan_name }}</td>
-        </tr>
-        <tr>
-            <th>料金</th>
-            <td>{{ number_format($reservation->price) }} 円</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
 
-    <p>ご不明な点がございましたら、お気軽にお問い合わせください。<br>
-    ご来館をお待ちしております。</p>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    このたびはご予約いただきありがとうございます。<br>
+    以下の内容で予約を承りました。
+</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">プラン名</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->plan_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">料金</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ number_format($reservation->price) }} 円</td>
+    </tr>
+</table>
+
+<p style="margin:0; font-size:15px; line-height:1.7;">
+    ご不明な点がございましたら、お気軽にお問い合わせください。<br>
+    ご来館をお待ちしております。
+</p>
+@endsection

--- a/hotel-reservation/src/resources/views/mail/reservation/received.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/received.blade.php
@@ -1,33 +1,30 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>予約受付のお知らせ</title>
-</head>
-<body>
-    <p>管理者様</p>
+@extends('layouts.mail')
 
-    <p>新しい予約を受け付けました。</p>
+@section('title', '予約受付のお知らせ')
 
-    <table>
-        <tr>
-            <th>氏名</th>
-            <td>{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
-        </tr>
-        <tr>
-            <th>メールアドレス</th>
-            <td>{{ $reservation->email }}</td>
-        </tr>
-        <tr>
-            <th>プラン名</th>
-            <td>{{ $reservation->plan_name }}</td>
-        </tr>
-        <tr>
-            <th>料金</th>
-            <td>{{ number_format($reservation->price) }} 円</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">管理者様</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    新しい予約を受け付けました。
+</p>
+
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">氏名</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->last_name }} {{ $reservation->first_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">メールアドレス</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->email }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">プラン名</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->plan_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">料金</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ number_format($reservation->price) }} 円</td>
+    </tr>
+</table>
+@endsection

--- a/hotel-reservation/src/resources/views/mail/reservation/reminder.blade.php
+++ b/hotel-reservation/src/resources/views/mail/reservation/reminder.blade.php
@@ -1,37 +1,36 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>【リマインド】明日のご宿泊について</title>
-</head>
-<body>
-    <p>{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
+@extends('layouts.mail')
 
-    <p>明日のご宿泊日が近づきましたのでご連絡いたします。<br>
-    以下の内容でご予約をお受けしております。</p>
+@section('title', '【リマインド】明日のご宿泊について')
 
-    <table>
-        <tr>
-            <th>プラン名</th>
-            <td>{{ $reservation->plan_name }}</td>
-        </tr>
-        <tr>
-            <th>チェックイン</th>
-            <td>{{ $reservation->reservationSlot->start->format('Y年m月d日') }}</td>
-        </tr>
-        <tr>
-            <th>チェックアウト</th>
-            <td>{{ $reservation->reservationSlot->end->format('Y年m月d日') }}</td>
-        </tr>
-        <tr>
-            <th>料金</th>
-            <td>{{ number_format($reservation->price) }} 円</td>
-        </tr>
-    </table>
+@section('content')
+<p style="margin:0 0 16px; font-size:16px;">{{ $reservation->last_name }} {{ $reservation->first_name }} 様</p>
 
-    <p>ご不明な点がございましたら、お気軽にお問い合わせください。<br>
-    ご来館を心よりお待ちしております。</p>
+<p style="margin:0 0 24px; font-size:15px; line-height:1.7;">
+    明日のご宿泊日が近づきましたのでご連絡いたします。<br>
+    以下の内容でご予約をお受けしております。
+</p>
 
-    <p>{{ config('app.name') }}</p>
-</body>
-</html>
+<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse; margin-bottom:24px;">
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">プラン名</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->plan_name }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">チェックイン</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->reservationSlot->start->format('Y年m月d日') }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">チェックアウト</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ $reservation->reservationSlot->end->format('Y年m月d日') }}</td>
+    </tr>
+    <tr>
+        <th style="width:40%; background-color:#f0f0f0; padding:12px 16px; text-align:left; font-size:14px; border:1px solid #dddddd;">料金</th>
+        <td style="padding:12px 16px; font-size:14px; border:1px solid #dddddd;">{{ number_format($reservation->price) }} 円</td>
+    </tr>
+</table>
+
+<p style="margin:0; font-size:15px; line-height:1.7;">
+    ご不明な点がございましたら、お気軽にお問い合わせください。<br>
+    ご来館を心よりお待ちしております。
+</p>
+@endsection


### PR DESCRIPTION
## Summary

- `layouts/mail.blade.php` を新設（ヘッダー・本文・フッターの3段構成）
- 全6テンプレートを `@extends('layouts.mail')` に統一
  - mail/reservation/confirmed, cancelled, received, reminder
  - mail/inquiry/completed, received
- メールクライアント互換のインラインCSSでテーブル・テキストをスタイリング

## Test plan

- [x] フルスイート 163件グリーン
- [x] Mailpit で全5種類のメール表示を確認（宿泊者・管理者それぞれ）

Closes #150