### PR TITLE
fix: メール送信処理をコントローラーからサービス層に移動 (#161)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Reservation/CancelController.php
@@ -3,19 +3,15 @@
 namespace App\Http\Controllers\Admin\Reservation;
 
 use App\Http\Controllers\Controller;
-use App\Mail\ReservationCancelledMail;
 use App\Models\Reservation;
 use App\Services\ReservationService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Mail;
 
 class CancelController extends Controller
 {
     public function __invoke(Reservation $reservation, ReservationService $service): RedirectResponse
     {
         $service->cancel($reservation);
-
-        Mail::send(new ReservationCancelledMail($reservation));
 
         return redirect()->route('admin.reservations.index')->with('success', '予約をキャンセルしました。');
     }

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
@@ -3,17 +3,13 @@
 namespace App\Http\Controllers\User\Contact;
 
 use App\Http\Controllers\Controller;
-use App\Mail\InquiryCompletedMail;
-use App\Mail\InquiryReceivedMail;
-use App\Models\Admin;
-use App\Models\Inquiry;
+use App\Services\ContactService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Mail;
 
 class StoreController extends Controller
 {
-    public function __invoke(Request $request): RedirectResponse
+    public function __invoke(Request $request, ContactService $service): RedirectResponse
     {
         $validated = $request->validate([
             'last_name'  => 'required|string|max:255',
@@ -24,13 +20,7 @@ class StoreController extends Controller
             'message'    => 'nullable|string',
         ]);
 
-        $inquiry = Inquiry::create($validated);
-
-        Mail::send(new InquiryCompletedMail($inquiry));
-
-        foreach (Admin::all() as $admin) {
-            Mail::send(new InquiryReceivedMail($inquiry, $admin->email));
-        }
+        $service->store($validated);
 
         return redirect()->route('user.contact.complete');
     }

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
@@ -3,15 +3,11 @@
 namespace App\Http\Controllers\User\Reservation;
 
 use App\Http\Controllers\Controller;
-use App\Mail\ReservationConfirmedMail;
-use App\Mail\ReservationReceivedMail;
 use App\Models\AccommodationPlan;
-use App\Models\Admin;
 use App\Models\ReservationSlot;
 use App\Services\ReservationService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Mail;
 
 class StoreController extends Controller
 {
@@ -34,15 +30,9 @@ class StoreController extends Controller
         $guestData = array_diff_key($validated, ['slot_id' => '', 'plan_id' => '']);
 
         try {
-            $reservation = $service->reserve($slot, $plan, $guestData);
+            $service->reserve($slot, $plan, $guestData);
         } catch (\RuntimeException $e) {
             return back()->withErrors(['slot_id' => $e->getMessage()]);
-        }
-
-        Mail::send(new ReservationConfirmedMail($reservation));
-
-        foreach (Admin::all() as $admin) {
-            Mail::send(new ReservationReceivedMail($reservation, $admin->email));
         }
 
         return redirect()->route('user.reservations.complete');

--- a/hotel-reservation/src/app/Services/ContactService.php
+++ b/hotel-reservation/src/app/Services/ContactService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use App\Mail\InquiryCompletedMail;
+use App\Mail\InquiryReceivedMail;
+use App\Models\Admin;
+use App\Models\Inquiry;
+use Illuminate\Support\Facades\Mail;
+
+class ContactService
+{
+    /** @param array<string, mixed> $data */
+    public function store(array $data): Inquiry
+    {
+        $inquiry = Inquiry::create($data);
+
+        Mail::send(new InquiryCompletedMail($inquiry));
+
+        foreach (Admin::all() as $admin) {
+            Mail::send(new InquiryReceivedMail($inquiry, $admin->email));
+        }
+
+        return $inquiry;
+    }
+}

--- a/hotel-reservation/src/app/Services/ReservationService.php
+++ b/hotel-reservation/src/app/Services/ReservationService.php
@@ -4,11 +4,16 @@ namespace App\Services;
 
 use App\Enums\ReservationSlotStatus;
 use App\Enums\ReservationStatus;
+use App\Mail\ReservationCancelledMail;
+use App\Mail\ReservationConfirmedMail;
+use App\Mail\ReservationReceivedMail;
 use App\Models\AccommodationPlan;
+use App\Models\Admin;
 use App\Models\PlanRoomPrice;
 use App\Models\Reservation;
 use App\Models\ReservationSlot;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 
 class ReservationService
 {
@@ -27,7 +32,7 @@ class ReservationService
             throw new \RuntimeException('この部屋タイプとプランの組み合わせの料金が設定されていません。');
         }
 
-        return DB::transaction(function () use ($slot, $plan, $price, $guestData): Reservation {
+        $reservation = DB::transaction(function () use ($slot, $plan, $price, $guestData): Reservation {
             $slot->update(['status' => ReservationSlotStatus::Booked]);
 
             return Reservation::create(array_merge([
@@ -37,6 +42,14 @@ class ReservationService
                 'price'                 => $price,
             ], $guestData));
         });
+
+        Mail::send(new ReservationConfirmedMail($reservation));
+
+        foreach (Admin::all() as $admin) {
+            Mail::send(new ReservationReceivedMail($reservation, $admin->email));
+        }
+
+        return $reservation;
     }
 
     public function cancel(Reservation $reservation): void
@@ -45,5 +58,7 @@ class ReservationService
             $reservation->update(['status' => ReservationStatus::Cancelled]);
             $reservation->reservationSlot()->update(['status' => ReservationSlotStatus::Available]);
         });
+
+        Mail::send(new ReservationCancelledMail($reservation));
     }
 }


### PR DESCRIPTION
## Summary
- `ContactService::store()` を新規作成し、お問い合わせ保存＋メール通知を一元化
- `ReservationService::reserve()` にゲスト向け・管理者向け予約完了メール送信を移動
- `ReservationService::cancel()` にキャンセルメール送信を移動
- `User/Contact/StoreController`・`User/Reservation/StoreController`・`Admin/Reservation/CancelController` からメール処理を除去

## Test plan
- [ ] 163件のテストが全て通過することを確認