### PR TITLE
feat: 予約・お問い合わせエンドポイントにレート制限を追加 (#163)

### DIFF
--- a/hotel-reservation/src/routes/web.php
+++ b/hotel-reservation/src/routes/web.php
@@ -43,7 +43,7 @@ Route::prefix('contact')->name('user.contact.')->group(function () {
     Route::get('/', UserContactCreateController::class)->name('create');
     Route::post('confirm', UserContactConfirmController::class)->name('confirm');
     Route::post('back', UserContactBackController::class)->name('back');
-    Route::post('/', UserContactStoreController::class)->name('store');
+    Route::post('/', UserContactStoreController::class)->name('store')->middleware('throttle:10,1');
     Route::get('complete', UserContactCompleteController::class)->name('complete');
 });
 
@@ -58,7 +58,7 @@ Route::prefix('plans')->name('user.plans.')->group(function () {
 Route::prefix('reservations')->name('user.reservations.')->group(function () {
     Route::get('create', UserReservationCreateController::class)->name('create');
     Route::post('confirm', UserReservationConfirmController::class)->name('confirm');
-    Route::post('/', UserReservationStoreController::class)->name('store');
+    Route::post('/', UserReservationStoreController::class)->name('store')->middleware('throttle:10,1');
     Route::get('/', fn () => redirect('/'))->name('index');
     Route::get('complete', fn () => view('user.reservation.complete'))->name('complete');
 });

--- a/hotel-reservation/src/tests/Feature/User/Contact/ContactRateLimitTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Contact/ContactRateLimitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature\User\Contact;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ContactRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::flush();
+        parent::tearDown();
+    }
+
+    public function test_1分間に10回を超えてお問い合わせを送信するとレート制限される(): void
+    {
+        Mail::fake();
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->post(route('user.contact.store'), $this->postData())
+                ->assertRedirect();
+        }
+
+        $this->post(route('user.contact.store'), $this->postData())
+            ->assertStatus(429);
+    }
+
+    /** @return array<string, mixed> */
+    private function postData(): array
+    {
+        return [
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'hanako@example.com',
+            'address'    => '大阪府大阪市1-1-1',
+            'phone'      => '0612345678',
+            'message'    => 'テストです。',
+        ];
+    }
+}

--- a/hotel-reservation/src/tests/Feature/User/Reservation/ReservationRateLimitTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Reservation/ReservationRateLimitTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature\User\Reservation;
+
+use App\Enums\ReservationSlotStatus;
+use App\Models\AccommodationPlan;
+use App\Models\Admin;
+use App\Models\PlanRoomPrice;
+use App\Models\ReservationSlot;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class ReservationRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::flush();
+        parent::tearDown();
+    }
+
+    public function test_1分間に10回を超えて予約するとレート制限される(): void
+    {
+        Mail::fake();
+
+        Admin::create([
+            'last_name'  => '管理',
+            'first_name' => '太郎',
+            'email'      => 'admin@example.com',
+            'password'   => Hash::make('password'),
+        ]);
+
+        $plan = AccommodationPlan::factory()->create();
+        $baseSlot = ReservationSlot::factory()->create(['status' => ReservationSlotStatus::Available]);
+
+        PlanRoomPrice::factory()->create([
+            'accommodation_plan_id' => $plan->id,
+            'room_type_id'          => $baseSlot->room_type_id,
+            'price'                 => 10000,
+        ]);
+
+        for ($i = 0; $i < 10; $i++) {
+            $slot = ($i === 0)
+                ? $baseSlot
+                : ReservationSlot::factory()->create([
+                    'room_type_id' => $baseSlot->room_type_id,
+                    'status'       => ReservationSlotStatus::Available,
+                ]);
+
+            $this->post(route('user.reservations.store'), $this->postData($slot->id, $plan->id))
+                ->assertRedirect();
+        }
+
+        $this->post(route('user.reservations.store'), $this->postData(9999, 9999))
+            ->assertStatus(429);
+    }
+
+    /** @return array<string, mixed> */
+    private function postData(int $slotId, int $planId): array
+    {
+        return [
+            'slot_id'    => $slotId,
+            'plan_id'    => $planId,
+            'last_name'  => '田中',
+            'first_name' => '花子',
+            'email'      => 'hanako@example.com',
+            'address'    => '大阪府大阪市1-1-1',
+            'phone'      => '0612345678',
+            'message'    => null,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /contact/`（お問い合わせ送信）に `throttle:10,1`（1分間10回上限）を追加
- `POST /reservations/`（予約確定）に `throttle:10,1` を追加
- レート制限超過時に 429 が返ることを確認するテストを 2件追加

## Test plan
- [x] 165件のテストが全て通過することを確認
- [x] `ContactRateLimitTest`・`ReservationRateLimitTest` が PASS