### PR TITLE
fix: プラン画像アップロードにファイルサイズ・拡張子制限を追加 (#164)

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
@@ -15,7 +15,7 @@ class StoreController extends Controller
             'name'        => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'images'      => ['nullable', 'array'],
-            'images.*'    => ['image'],
+            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
             'prices'      => ['nullable', 'array'],
             'prices.*'    => ['nullable', 'integer', 'min:0'],
         ]);

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
@@ -16,7 +16,7 @@ class UpdateController extends Controller
             'name'        => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'images'      => ['nullable', 'array'],
-            'images.*'    => ['image'],
+            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
             'prices'      => ['nullable', 'array'],
             'prices.*'    => ['nullable', 'integer', 'min:0'],
         ]);

--- a/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
@@ -135,6 +135,26 @@ class PlanControllerTest extends TestCase
         $this->assertDatabaseCount('accommodation_plans', 0);
     }
 
+    public function test_2MBを超える画像はアップロードできない(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.plans.store'), [
+                'name'   => 'テストプラン',
+                'images' => [UploadedFile::fake()->image('large.jpg')->size(2049)],
+            ])
+            ->assertSessionHasErrors('images.0');
+    }
+
+    public function test_許可されていない拡張子の画像はアップロードできない(): void
+    {
+        $this->actingAs($this->admin, 'admin')
+            ->post(route('admin.plans.store'), [
+                'name'   => 'テストプラン',
+                'images' => [UploadedFile::fake()->create('document.pdf', 100, 'application/pdf')],
+            ])
+            ->assertSessionHasErrors('images.0');
+    }
+
     // ----------------------------------------------------------------
     // EditController
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- \`images.*\` バリデーションに \`max:2048\`（2MB上限）と \`mimes:jpg,jpeg,png,webp\` を追加
- \`Admin/Plan/StoreController\` と \`Admin/Plan/UpdateController\` の両方に適用
- 2MB超過・非許可拡張子それぞれのテストを追加

## Test plan
- [x] 167件のテストが全て通過することを確認