### PR TITLE
chore: 動作検証用のSeederを整備する（Admin複数・予約・問い合わせ）(#180)

### DIFF
--- a/hotel-reservation/src/database/seeders/AdminSeeder.php
+++ b/hotel-reservation/src/database/seeders/AdminSeeder.php
@@ -10,11 +10,19 @@ class AdminSeeder extends Seeder
 {
     public function run(): void
     {
-        Admin::create([
-            'last_name' => '山田',
-            'first_name' => '太郎',
-            'email' => 'admin@example.com',
-            'password' => Hash::make('password'),
-        ]);
+        $admins = [
+            ['last_name' => '山田', 'first_name' => '太郎',  'email' => 'admin@example.com'],
+            ['last_name' => '佐藤', 'first_name' => '花子',  'email' => 'sato@example.com'],
+            ['last_name' => '鈴木', 'first_name' => '一郎',  'email' => 'suzuki@example.com'],
+            ['last_name' => '田中', 'first_name' => '美咲',  'email' => 'tanaka@example.com'],
+            ['last_name' => '伊藤', 'first_name' => '健太',  'email' => 'ito@example.com'],
+        ];
+
+        foreach ($admins as $admin) {
+            Admin::create([
+                ...$admin,
+                'password' => Hash::make('password'),
+            ]);
+        }
     }
 }

--- a/hotel-reservation/src/database/seeders/DatabaseSeeder.php
+++ b/hotel-reservation/src/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,7 @@ class DatabaseSeeder extends Seeder
         $this->call(RoomTypeSeeder::class);
         $this->call(AccommodationPlanSeeder::class);
         $this->call(ReservationSlotSeeder::class);
+        $this->call(ReservationSeeder::class);
+        $this->call(InquirySeeder::class);
     }
 }

--- a/hotel-reservation/src/database/seeders/InquirySeeder.php
+++ b/hotel-reservation/src/database/seeders/InquirySeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\InquiryStatus;
+use App\Models\Inquiry;
+use Illuminate\Database\Seeder;
+
+class InquirySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $subjects = [
+            '予約について',
+            'キャンセルポリシーについて',
+            'チェックイン時間について',
+            '駐車場の有無について',
+            '食事アレルギーについて',
+            'アクセス方法について',
+            '特別なリクエストについて',
+            '周辺観光スポットについて',
+            '連泊割引について',
+            '団体予約について',
+        ];
+
+        $statuses = [
+            InquiryStatus::Pending,
+            InquiryStatus::Pending,
+            InquiryStatus::Pending,
+            InquiryStatus::InProgress,
+            InquiryStatus::InProgress,
+            InquiryStatus::Resolved,
+        ];
+
+        for ($i = 0; $i < 30; $i++) {
+            Inquiry::create([
+                'last_name'  => fake('ja_JP')->lastName(),
+                'first_name' => fake('ja_JP')->firstName(),
+                'email'      => fake()->safeEmail(),
+                'address'    => fake('ja_JP')->address(),
+                'phone'      => fake('ja_JP')->phoneNumber(),
+                'message'    => fake()->randomElement($subjects) . 'について質問があります。' . fake('ja_JP')->text(50),
+                'status'     => fake()->randomElement($statuses),
+            ]);
+        }
+    }
+}

--- a/hotel-reservation/src/database/seeders/ReservationSeeder.php
+++ b/hotel-reservation/src/database/seeders/ReservationSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\ReservationSlotStatus;
+use App\Enums\ReservationStatus;
+use App\Models\AccommodationPlan;
+use App\Models\Reservation;
+use App\Models\ReservationSlot;
+use Illuminate\Database\Seeder;
+
+class ReservationSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $bookedSlots = ReservationSlot::where('status', ReservationSlotStatus::Booked)->get();
+
+        foreach ($bookedSlots as $slot) {
+            $plan = AccommodationPlan::whereHas('planRoomPrices', function ($q) use ($slot) {
+                $q->where('room_type_id', $slot->room_type_id);
+            })->inRandomOrder()->first();
+
+            if (! $plan) {
+                continue;
+            }
+
+            $price = $plan->planRoomPrices
+                ->firstWhere('room_type_id', $slot->room_type_id)
+                ?->price ?? 0;
+
+            Reservation::create([
+                'reservation_slot_id'   => $slot->id,
+                'accommodation_plan_id' => $plan->id,
+                'plan_name'             => $plan->name,
+                'price'                 => $price,
+                'last_name'             => fake('ja_JP')->lastName(),
+                'first_name'            => fake('ja_JP')->firstName(),
+                'email'                 => fake()->safeEmail(),
+                'address'               => fake('ja_JP')->address(),
+                'phone'                 => fake('ja_JP')->phoneNumber(),
+                'message'               => fake()->optional(0.4)->sentence(),
+                'status'                => fake()->randomElement([
+                    ReservationStatus::Confirmed,
+                    ReservationStatus::Confirmed,
+                    ReservationStatus::Cancelled,
+                ]),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `AdminSeeder`: Admin を 1件 → 5件に拡充
- `ReservationSeeder` を新規作成。Booked スロットに対して予約データを生成（171件）
- `InquirySeeder` を新規作成。各ステータス混在で 30件生成
- `DatabaseSeeder` に上記2つを追加

## 投入データ量

| テーブル | 件数 |
|---------|------|
| admins | 5 |
| reservations | 171（Confirmed: 114 / Cancelled: 57） |
| inquiries | 30（Pending / InProgress / Resolved 混在） |

## 関連

#175 #177 #178 の検証前提 Issue

Closes #180