### PR TITLE
fix: プラン画像のファイル名を正規化する（hashName使用）(#176)

### DIFF
--- a/hotel-reservation/src/app/Services/AccommodationPlanService.php
+++ b/hotel-reservation/src/app/Services/AccommodationPlanService.php
@@ -61,7 +61,7 @@ class AccommodationPlanService
         foreach ($images as $image) {
             $path = $image->store('plan-images', 'public');
             $plan->planImages()->create([
-                'name'       => $image->getClientOriginalName(),
+                'name'       => basename((string) $path),
                 'image_path' => $path,
             ]);
         }

--- a/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
@@ -99,8 +99,9 @@ class AccommodationPlanServiceTest extends TestCase
         $newImage = UploadedFile::fake()->image('new.jpg');
         $this->service->update($plan, $plan->name, null, [$newImage], []);
 
+        $freshImage = $plan->fresh()->planImages->first();
         $this->assertCount(1, $plan->fresh()->planImages);
-        $this->assertSame('new.jpg', $plan->fresh()->planImages->first()->name);
+        $this->assertSame(basename($freshImage->image_path), $freshImage->name);
     }
 
     public function test_編集時に画像を指定しない場合は既存画像が保持される(): void


### PR DESCRIPTION
## Summary

- `AccommodationPlanService::saveImages()` でユーザー入力のファイル名をそのまま保存していた問題を修正
- `getClientOriginalName()` → `basename($path)` に変更し、`store()` が生成したハッシュ名を `name` カラムに保存するよう統一

## 変更内容

- `app/Services/AccommodationPlanService.php`: `saveImages()` の `name` をパスから派生させる
- `tests/Feature/Services/AccommodationPlanServiceTest.php`: 新しい振る舞いに合わせてアサーションを修正

Closes #176