### PR TITLE
fix: Admin全件取得でのメール送信ループを最適化する (#175)

### DIFF
--- a/hotel-reservation/src/app/Mail/InquiryReceivedMail.php
+++ b/hotel-reservation/src/app/Mail/InquiryReceivedMail.php
@@ -14,16 +14,19 @@ class InquiryReceivedMail extends Mailable
     use Queueable;
     use SerializesModels;
 
+    /**
+     * @param string[] $adminEmails
+     */
     public function __construct(
         public readonly Inquiry $inquiry,
-        public readonly string $adminEmail,
+        public readonly array $adminEmails,
     ) {
     }
 
     public function envelope(): Envelope
     {
         return new Envelope(
-            to:      [$this->adminEmail],
+            to:      $this->adminEmails,
             subject: 'お問い合わせを受け付けました',
         );
     }

--- a/hotel-reservation/src/app/Mail/ReservationReceivedMail.php
+++ b/hotel-reservation/src/app/Mail/ReservationReceivedMail.php
@@ -14,16 +14,19 @@ class ReservationReceivedMail extends Mailable
     use Queueable;
     use SerializesModels;
 
+    /**
+     * @param string[] $adminEmails
+     */
     public function __construct(
         public readonly Reservation $reservation,
-        public readonly string $adminEmail,
+        public readonly array $adminEmails,
     ) {
     }
 
     public function envelope(): Envelope
     {
         return new Envelope(
-            to:      [$this->adminEmail],
+            to:      $this->adminEmails,
             subject: '予約受付のお知らせ',
         );
     }

--- a/hotel-reservation/src/app/Services/ContactService.php
+++ b/hotel-reservation/src/app/Services/ContactService.php
@@ -17,8 +17,9 @@ class ContactService
 
         Mail::send(new InquiryCompletedMail($inquiry));
 
-        foreach (Admin::all() as $admin) {
-            Mail::send(new InquiryReceivedMail($inquiry, $admin->email));
+        $adminEmails = Admin::pluck('email')->all();
+        if ($adminEmails !== []) {
+            Mail::send(new InquiryReceivedMail($inquiry, $adminEmails));
         }
 
         return $inquiry;

--- a/hotel-reservation/src/app/Services/ReservationService.php
+++ b/hotel-reservation/src/app/Services/ReservationService.php
@@ -45,8 +45,9 @@ class ReservationService
 
         Mail::send(new ReservationConfirmedMail($reservation));
 
-        foreach (Admin::all() as $admin) {
-            Mail::send(new ReservationReceivedMail($reservation, $admin->email));
+        $adminEmails = Admin::pluck('email')->all();
+        if ($adminEmails !== []) {
+            Mail::send(new ReservationReceivedMail($reservation, $adminEmails));
         }
 
         return $reservation;

--- a/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/ReservationServiceTest.php
@@ -10,6 +10,7 @@ use App\Models\Reservation;
 use App\Models\ReservationSlot;
 use App\Services\ReservationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class ReservationServiceTest extends TestCase
@@ -21,6 +22,7 @@ class ReservationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        Mail::fake();
         $this->service = new ReservationService();
     }
 

--- a/hotel-reservation/src/tests/Unit/Mail/InquiryReceivedMailTest.php
+++ b/hotel-reservation/src/tests/Unit/Mail/InquiryReceivedMailTest.php
@@ -26,19 +26,19 @@ class InquiryReceivedMailTest extends TestCase
 
     public function test_件名がお問い合わせを受け付けましたである(): void
     {
-        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
+        $mail = new InquiryReceivedMail($this->inquiry, ['admin@example.com']);
         $mail->assertHasSubject('お問い合わせを受け付けました');
     }
 
     public function test_宛先が指定した管理者メールアドレスである(): void
     {
-        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
-        $mail->assertHasTo('admin@example.com');
+        $mail = new InquiryReceivedMail($this->inquiry, ['admin@example.com']);
+        $mail->assertHasTo(['admin@example.com']);
     }
 
     public function test_本文にお問い合わせ者の氏名が含まれる(): void
     {
-        $mail = new InquiryReceivedMail($this->inquiry, 'admin@example.com');
+        $mail = new InquiryReceivedMail($this->inquiry, ['admin@example.com']);
         $mail->assertSeeInHtml('田中');
         $mail->assertSeeInHtml('花子');
     }

--- a/hotel-reservation/src/tests/Unit/Mail/ReservationReceivedMailTest.php
+++ b/hotel-reservation/src/tests/Unit/Mail/ReservationReceivedMailTest.php
@@ -27,26 +27,26 @@ class ReservationReceivedMailTest extends TestCase
 
     public function test_件名が予約受付のお知らせである(): void
     {
-        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail = new ReservationReceivedMail($this->reservation, ['admin@example.com']);
         $mail->assertHasSubject('予約受付のお知らせ');
     }
 
     public function test_宛先が指定した管理者メールアドレスである(): void
     {
-        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
-        $mail->assertHasTo('admin@example.com');
+        $mail = new ReservationReceivedMail($this->reservation, ['admin@example.com']);
+        $mail->assertHasTo(['admin@example.com']);
     }
 
     public function test_本文に宿泊者の氏名が含まれる(): void
     {
-        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail = new ReservationReceivedMail($this->reservation, ['admin@example.com']);
         $mail->assertSeeInHtml('田中');
         $mail->assertSeeInHtml('花子');
     }
 
     public function test_本文にプラン名が含まれる(): void
     {
-        $mail = new ReservationReceivedMail($this->reservation, 'admin@example.com');
+        $mail = new ReservationReceivedMail($this->reservation, ['admin@example.com']);
         $mail->assertSeeInHtml('スタンダードプラン');
     }
 }


### PR DESCRIPTION
## Summary

- `ReservationReceivedMail` / `InquiryReceivedMail` の宛先を `string` → `string[]` に変更
- `Admin::all()` でループ送信 → `Admin::pluck('email')` で1回の送信にまとめる
- Admin が 0件の場合は送信をスキップするガードを追加

## 変更内容

| ファイル | 変更 |
|---------|------|
| `app/Mail/ReservationReceivedMail.php` | `adminEmail: string` → `adminEmails: string[]` |
| `app/Mail/InquiryReceivedMail.php` | `adminEmail: string` → `adminEmails: string[]` |
| `app/Services/ReservationService.php` | ループ削除 → `pluck('email')` + 空配列ガード |
| `app/Services/ContactService.php` | 同上 |
| `tests/Unit/Mail/ReservationReceivedMailTest.php` | コンストラクタ引数を配列に修正 |
| `tests/Unit/Mail/InquiryReceivedMailTest.php` | 同上 |
| `tests/Feature/Services/ReservationServiceTest.php` | `Mail::fake()` を追加 |

Closes #175