### PR TITLE
feat: メール送信を非同期化する（Mail::queue()）(#177)

### DIFF
--- a/hotel-reservation/src/app/Services/ContactService.php
+++ b/hotel-reservation/src/app/Services/ContactService.php
@@ -15,11 +15,11 @@ class ContactService
     {
         $inquiry = Inquiry::create($data);
 
-        Mail::send(new InquiryCompletedMail($inquiry));
+        Mail::queue(new InquiryCompletedMail($inquiry));
 
         $adminEmails = Admin::pluck('email')->all();
         if ($adminEmails !== []) {
-            Mail::send(new InquiryReceivedMail($inquiry, $adminEmails));
+            Mail::queue(new InquiryReceivedMail($inquiry, $adminEmails));
         }
 
         return $inquiry;

--- a/hotel-reservation/src/app/Services/ReservationService.php
+++ b/hotel-reservation/src/app/Services/ReservationService.php
@@ -43,11 +43,11 @@ class ReservationService
             ], $guestData));
         });
 
-        Mail::send(new ReservationConfirmedMail($reservation));
+        Mail::queue(new ReservationConfirmedMail($reservation));
 
         $adminEmails = Admin::pluck('email')->all();
         if ($adminEmails !== []) {
-            Mail::send(new ReservationReceivedMail($reservation, $adminEmails));
+            Mail::queue(new ReservationReceivedMail($reservation, $adminEmails));
         }
 
         return $reservation;
@@ -60,6 +60,6 @@ class ReservationService
             $reservation->reservationSlot()->update(['status' => ReservationSlotStatus::Available]);
         });
 
-        Mail::send(new ReservationCancelledMail($reservation));
+        Mail::queue(new ReservationCancelledMail($reservation));
     }
 }

--- a/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Reservation/ReservationControllerTest.php
@@ -117,7 +117,7 @@ class ReservationControllerTest extends TestCase
         $this->actingAs($this->admin, 'admin')
             ->delete(route('admin.reservations.cancel', $reservation));
 
-        Mail::assertSent(ReservationCancelledMail::class, fn ($mail) => $mail->hasTo($reservation->email));
+        Mail::assertQueued(ReservationCancelledMail::class, fn ($mail) => $mail->hasTo($reservation->email));
     }
 
     public function test_キャンセル済みの予約を再キャンセルしても冪等に動作する(): void

--- a/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Contact/ContactControllerTest.php
@@ -77,7 +77,7 @@ class ContactControllerTest extends TestCase
 
         $this->post(route('user.contact.store'), $this->postData());
 
-        Mail::assertSent(InquiryReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
+        Mail::assertQueued(InquiryReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
     }
 
     public function test_送信後に宿泊者へお問い合わせ完了メールが送信される(): void
@@ -86,7 +86,7 @@ class ContactControllerTest extends TestCase
 
         $this->post(route('user.contact.store'), $this->postData());
 
-        Mail::assertSent(InquiryCompletedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
+        Mail::assertQueued(InquiryCompletedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
     }
 
     // ----------------------------------------------------------------

--- a/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Reservation/ReservationFlowControllerTest.php
@@ -113,7 +113,7 @@ class ReservationFlowControllerTest extends TestCase
 
         $this->post(route('user.reservations.store'), $this->postData($slot->id, $plan->id));
 
-        Mail::assertSent(ReservationConfirmedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
+        Mail::assertQueued(ReservationConfirmedMail::class, fn ($mail) => $mail->hasTo('hanako@example.com'));
     }
 
     public function test_予約完了後に管理者へ予約受付メールが送信される(): void
@@ -129,7 +129,7 @@ class ReservationFlowControllerTest extends TestCase
 
         $this->post(route('user.reservations.store'), $this->postData($slot->id, $plan->id));
 
-        Mail::assertSent(ReservationReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
+        Mail::assertQueued(ReservationReceivedMail::class, fn ($mail) => $mail->hasTo('admin@example.com'));
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `ReservationService` / `ContactService` の `Mail::send()` を `Mail::queue()` に変更
- `QUEUE_CONNECTION=database` と `jobs` テーブルは既存設定を使用（追加設定不要）
- リマインドバッチはバッチ処理自体が非同期のため `send()` のまま維持

## ワーカーの起動

```bash
./vendor/bin/sail artisan queue:work
```

## テスト変更

`Mail::assertSent()` → `Mail::assertQueued()` に変更（5箇所）

Closes #177