### PR TITLE
chore: DBインデックスを追加する (#178)

### DIFF
--- a/hotel-reservation/src/database/migrations/2026_05_05_044510_add_indexes_to_reservations_inquiries_plans_slots_tables.php
+++ b/hotel-reservation/src/database/migrations/2026_05_05_044510_add_indexes_to_reservations_inquiries_plans_slots_tables.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->index('status');
+        });
+
+        Schema::table('inquiries', function (Blueprint $table) {
+            $table->index('status');
+        });
+
+        Schema::table('accommodation_plans', function (Blueprint $table) {
+            $table->index('deleted_at');
+        });
+
+        Schema::table('reservation_slots', function (Blueprint $table) {
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservations', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+        });
+
+        Schema::table('inquiries', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+        });
+
+        Schema::table('accommodation_plans', function (Blueprint $table) {
+            $table->dropIndex(['deleted_at']);
+        });
+
+        Schema::table('reservation_slots', function (Blueprint $table) {
+            $table->dropIndex(['status']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

以下のカラムにインデックスを追加するマイグレーションを作成。

| テーブル | カラム | 用途 |
|---------|--------|------|
| `reservations` | `status` | ステータス別集計（ダッシュボード等） |
| `inquiries` | `status` | 未対応件数カウント |
| `accommodation_plans` | `deleted_at` | SoftDelete + `withoutTrashed()` |
| `reservation_slots` | `status` | 空室検索時のフィルタ |

Closes #178