### PR TITLE
refactor: CalendarAvailability::fromCount()を追加してマジックナンバーを除去する (#179)

### DIFF
--- a/hotel-reservation/src/app/Enums/CalendarAvailability.php
+++ b/hotel-reservation/src/app/Enums/CalendarAvailability.php
@@ -7,4 +7,13 @@ enum CalendarAvailability
     case Available;   // 空きあり（2枠以上）
     case Limited;     // 残りわずか（1枠）
     case Unavailable; // 空きなし
+
+    public static function fromCount(int $count): self
+    {
+        return match (true) {
+            $count >= 2 => self::Available,
+            $count === 1 => self::Limited,
+            default      => self::Unavailable,
+        };
+    }
 }

--- a/hotel-reservation/src/app/Services/CalendarService.php
+++ b/hotel-reservation/src/app/Services/CalendarService.php
@@ -38,11 +38,7 @@ class CalendarService
             $availSlots = $daySlots->filter(fn ($s) => $s->status === ReservationSlotStatus::Available);
             $availCount = $availSlots->count();
 
-            $availability = match (true) {
-                $availCount >= 2 => CalendarAvailability::Available,
-                $availCount === 1 => CalendarAvailability::Limited,
-                default          => CalendarAvailability::Unavailable,
-            };
+            $availability = CalendarAvailability::fromCount($availCount);
 
             $calendar[$dateKey] = [
                 'availability' => $availability,


### PR DESCRIPTION
## Summary

- `CalendarAvailability` Enum に `fromCount(int $count): self` を追加
- `CalendarService` 内の `match` 式と `2`, `1` のマジックナンバーを `fromCount()` 1行に置き換え

## 変更前後

```php
// Before
$availability = match (true) {
    $availCount >= 2 => CalendarAvailability::Available,
    $availCount === 1 => CalendarAvailability::Limited,
    default          => CalendarAvailability::Unavailable,
};

// After
$availability = CalendarAvailability::fromCount($availCount);
```

Closes #179