### PR TITLE
refactor: FormRequestクラスを導入してバリデーションをコントローラーから分離する

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Auth\LoginRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -15,12 +16,9 @@ class LoginController extends Controller
         return view('admin.auth.login');
     }
 
-    public function store(Request $request): RedirectResponse
+    public function store(LoginRequest $request): RedirectResponse
     {
-        $credentials = $request->validate([
-            'email' => ['required', 'email'],
-            'password' => ['required'],
-        ]);
+        $credentials = $request->validated();
 
         if (!Auth::guard('admin')->attempt($credentials, $request->boolean('remember'))) {
             return back()->withErrors([

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Inquiry/UpdateController.php
@@ -2,19 +2,16 @@
 
 namespace App\Http\Controllers\Admin\Inquiry;
 
-use App\Enums\InquiryStatus;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Inquiry\UpdateInquiryRequest;
 use App\Models\Inquiry;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class UpdateController extends Controller
 {
-    public function __invoke(Request $request, Inquiry $inquiry): RedirectResponse
+    public function __invoke(UpdateInquiryRequest $request, Inquiry $inquiry): RedirectResponse
     {
-        $validated = $request->validate([
-            'status' => ['required', 'integer', 'in:' . implode(',', array_column(InquiryStatus::cases(), 'value'))],
-        ]);
+        $validated = $request->validated();
 
         $inquiry->update(['status' => $validated['status']]);
 

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/StoreController.php
@@ -3,22 +3,15 @@
 namespace App\Http\Controllers\Admin\Plan;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Plan\PlanRequest;
 use App\Services\AccommodationPlanService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
-    public function __invoke(Request $request, AccommodationPlanService $service): RedirectResponse
+    public function __invoke(PlanRequest $request, AccommodationPlanService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'name'        => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'images'      => ['nullable', 'array'],
-            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
-            'prices'      => ['nullable', 'array'],
-            'prices.*'    => ['nullable', 'integer', 'min:0'],
-        ]);
+        $validated = $request->validated();
 
         $prices = array_filter(
             $validated['prices'] ?? [],

--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
@@ -3,23 +3,16 @@
 namespace App\Http\Controllers\Admin\Plan;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\Plan\PlanRequest;
 use App\Models\AccommodationPlan;
 use App\Services\AccommodationPlanService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class UpdateController extends Controller
 {
-    public function __invoke(Request $request, AccommodationPlan $plan, AccommodationPlanService $service): RedirectResponse
+    public function __invoke(PlanRequest $request, AccommodationPlan $plan, AccommodationPlanService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'name'        => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'images'      => ['nullable', 'array'],
-            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
-            'prices'      => ['nullable', 'array'],
-            'prices.*'    => ['nullable', 'integer', 'min:0'],
-        ]);
+        $validated = $request->validated();
 
         $prices = array_filter(
             $validated['prices'] ?? [],

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/BulkStoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/BulkStoreController.php
@@ -3,21 +3,17 @@
 namespace App\Http\Controllers\Admin\ReservationSlot;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ReservationSlot\BulkStoreReservationSlotRequest;
 use App\Models\RoomType;
 use App\Services\ReservationSlotService;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class BulkStoreController extends Controller
 {
-    public function __invoke(Request $request, ReservationSlotService $service): RedirectResponse
+    public function __invoke(BulkStoreReservationSlotRequest $request, ReservationSlotService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
-            'from'         => ['required', 'date', 'before:to'],
-            'to'           => ['required', 'date', 'after:from'],
-        ]);
+        $validated = $request->validated();
 
         $roomType = RoomType::findOrFail($validated['room_type_id']);
         $created  = $service->bulkStore(

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/StoreController.php
@@ -3,21 +3,17 @@
 namespace App\Http\Controllers\Admin\ReservationSlot;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ReservationSlot\ReservationSlotRequest;
 use App\Models\RoomType;
 use App\Services\ReservationSlotService;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
-    public function __invoke(Request $request, ReservationSlotService $service): RedirectResponse
+    public function __invoke(ReservationSlotRequest $request, ReservationSlotService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
-            'start'        => ['required', 'date', 'before:end'],
-            'end'          => ['required', 'date', 'after:start'],
-        ]);
+        $validated = $request->validated();
 
         $roomType = RoomType::findOrFail($validated['room_type_id']);
 

--- a/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/ReservationSlot/UpdateController.php
@@ -3,25 +3,21 @@
 namespace App\Http\Controllers\Admin\ReservationSlot;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\ReservationSlot\ReservationSlotRequest;
 use App\Models\ReservationSlot;
 use App\Models\RoomType;
 use App\Services\ReservationSlotService;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class UpdateController extends Controller
 {
     public function __invoke(
-        Request $request,
+        ReservationSlotRequest $request,
         ReservationSlot $reservationSlot,
         ReservationSlotService $service
     ): RedirectResponse {
-        $validated = $request->validate([
-            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
-            'start'        => ['required', 'date', 'before:end'],
-            'end'          => ['required', 'date', 'after:start'],
-        ]);
+        $validated = $request->validated();
 
         $roomType = RoomType::findOrFail($validated['room_type_id']);
 

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/ConfirmController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/ConfirmController.php
@@ -3,21 +3,14 @@
 namespace App\Http\Controllers\User\Contact;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Http\Requests\User\Contact\ContactRequest;
 use Illuminate\View\View;
 
 class ConfirmController extends Controller
 {
-    public function __invoke(Request $request): View
+    public function __invoke(ContactRequest $request): View
     {
-        $validated = $request->validate([
-            'last_name'  => 'required|string|max:255',
-            'first_name' => 'required|string|max:255',
-            'email'      => 'required|email|max:255',
-            'address'    => 'required|string|max:255',
-            'phone'      => 'required|string|max:20',
-            'message'    => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         return view('user.contact.confirm', compact('validated'));
     }

--- a/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Contact/StoreController.php
@@ -3,22 +3,15 @@
 namespace App\Http\Controllers\User\Contact;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\Contact\ContactRequest;
 use App\Services\ContactService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
-    public function __invoke(Request $request, ContactService $service): RedirectResponse
+    public function __invoke(ContactRequest $request, ContactService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'last_name'  => 'required|string|max:255',
-            'first_name' => 'required|string|max:255',
-            'email'      => 'required|email|max:255',
-            'address'    => 'required|string|max:255',
-            'phone'      => 'required|string|max:20',
-            'message'    => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         $service->store($validated);
 

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/ConfirmController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/ConfirmController.php
@@ -3,26 +3,17 @@
 namespace App\Http\Controllers\User\Reservation;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\Reservation\ReservationRequest;
 use App\Models\AccommodationPlan;
 use App\Models\PlanRoomPrice;
 use App\Models\ReservationSlot;
-use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class ConfirmController extends Controller
 {
-    public function __invoke(Request $request): View
+    public function __invoke(ReservationRequest $request): View
     {
-        $validated = $request->validate([
-            'slot_id'    => 'required|exists:reservation_slots,id',
-            'plan_id'    => 'required|exists:accommodation_plans,id',
-            'last_name'  => 'required|string|max:255',
-            'first_name' => 'required|string|max:255',
-            'email'      => 'required|email|max:255',
-            'address'    => 'required|string|max:255',
-            'phone'      => 'required|string|max:20',
-            'message'    => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         $slot  = ReservationSlot::findOrFail($validated['slot_id']);
         $plan  = AccommodationPlan::findOrFail($validated['plan_id']);

--- a/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
+++ b/hotel-reservation/src/app/Http/Controllers/User/Reservation/StoreController.php
@@ -3,26 +3,17 @@
 namespace App\Http\Controllers\User\Reservation;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\Reservation\ReservationRequest;
 use App\Models\AccommodationPlan;
 use App\Models\ReservationSlot;
 use App\Services\ReservationService;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
-    public function __invoke(Request $request, ReservationService $service): RedirectResponse
+    public function __invoke(ReservationRequest $request, ReservationService $service): RedirectResponse
     {
-        $validated = $request->validate([
-            'slot_id'    => 'required|exists:reservation_slots,id',
-            'plan_id'    => 'required|exists:accommodation_plans,id',
-            'last_name'  => 'required|string|max:255',
-            'first_name' => 'required|string|max:255',
-            'email'      => 'required|email|max:255',
-            'address'    => 'required|string|max:255',
-            'phone'      => 'required|string|max:20',
-            'message'    => 'nullable|string',
-        ]);
+        $validated = $request->validated();
 
         $slot = ReservationSlot::findOrFail($validated['slot_id']);
         $plan = AccommodationPlan::findOrFail($validated['plan_id']);

--- a/hotel-reservation/src/app/Http/Requests/Admin/Auth/LoginRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/Auth/LoginRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'email'    => ['required', 'email'],
+            'password' => ['required'],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/Admin/Inquiry/UpdateInquiryRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/Inquiry/UpdateInquiryRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Admin\Inquiry;
+
+use App\Enums\InquiryStatus;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateInquiryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', 'integer', 'in:' . implode(',', array_column(InquiryStatus::cases(), 'value'))],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Admin\Plan;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PlanRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'name'        => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'images'      => ['nullable', 'array'],
+            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
+            'prices'      => ['nullable', 'array'],
+            'prices.*'    => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/Admin/ReservationSlot/BulkStoreReservationSlotRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/ReservationSlot/BulkStoreReservationSlotRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Admin\ReservationSlot;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BulkStoreReservationSlotRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
+            'from'         => ['required', 'date', 'before:to'],
+            'to'           => ['required', 'date', 'after:from'],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/Admin/ReservationSlot/ReservationSlotRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/ReservationSlot/ReservationSlotRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Admin\ReservationSlot;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReservationSlotRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'room_type_id' => ['required', 'integer', 'exists:room_types,id'],
+            'start'        => ['required', 'date', 'before:end'],
+            'end'          => ['required', 'date', 'after:start'],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/User/Contact/ContactRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/User/Contact/ContactRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\User\Contact;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ContactRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'last_name'  => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'email'      => ['required', 'email', 'max:255'],
+            'address'    => ['required', 'string', 'max:255'],
+            'phone'      => ['required', 'string', 'max:20'],
+            'message'    => ['nullable', 'string'],
+        ];
+    }
+}

--- a/hotel-reservation/src/app/Http/Requests/User/Reservation/ReservationRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/User/Reservation/ReservationRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\User\Reservation;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReservationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, list<string>> */
+    public function rules(): array
+    {
+        return [
+            'slot_id'    => ['required', 'exists:reservation_slots,id'],
+            'plan_id'    => ['required', 'exists:accommodation_plans,id'],
+            'last_name'  => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'email'      => ['required', 'email', 'max:255'],
+            'address'    => ['required', 'string', 'max:255'],
+            'phone'      => ['required', 'string', 'max:20'],
+            'message'    => ['nullable', 'string'],
+        ];
+    }
+}


### PR DESCRIPTION
closes #162

## 変更内容

コントローラーにインラインで書かれていたバリデーションルールを FormRequest クラスに移動した。

### 作成した FormRequest クラス（7件）

| クラス | 対応コントローラー |
|---|---|
| `Admin/Auth/LoginRequest` | `LoginController::store()` |
| `Admin/Inquiry/UpdateInquiryRequest` | `Inquiry/UpdateController` |
| `Admin/Plan/PlanRequest` | `Plan/StoreController`, `Plan/UpdateController`（共有） |
| `Admin/ReservationSlot/ReservationSlotRequest` | `ReservationSlot/StoreController`, `ReservationSlot/UpdateController`（共有） |
| `Admin/ReservationSlot/BulkStoreReservationSlotRequest` | `ReservationSlot/BulkStoreController` |
| `User/Contact/ContactRequest` | `Contact/ConfirmController`, `Contact/StoreController`（共有） |
| `User/Reservation/ReservationRequest` | `Reservation/ConfirmController`, `Reservation/StoreController`（共有） |

### 変更方針

- `authorize()` はすべて `true`（認可はミドルウェアで処理済み）
- ルールが同一なコントローラーペアは 1 つの FormRequest を共有
- コントローラー側は `$request->validated()` で取得するだけになり、バリデーションロジックがゼロに

## テスト

既存テスト 175 件がすべてパス。Larastan・PHP CS Fixer もエラーなし。