### PR TITLE
fix: プラン画像アップロードの上限を 2MB → 15MB に緩和する

### DIFF
--- a/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
@@ -18,7 +18,7 @@ class PlanRequest extends FormRequest
             'name'        => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string'],
             'images'      => ['nullable', 'array'],
-            'images.*'    => ['image', 'max:2048', 'mimes:jpg,jpeg,png,webp'],
+            'images.*'    => ['image', 'max:15360', 'mimes:jpg,jpeg,png,webp'],
             'prices'      => ['nullable', 'array'],
             'prices.*'    => ['nullable', 'integer', 'min:0'],
         ];

--- a/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
@@ -135,12 +135,12 @@ class PlanControllerTest extends TestCase
         $this->assertDatabaseCount('accommodation_plans', 0);
     }
 
-    public function test_2MBを超える画像はアップロードできない(): void
+    public function test_15MBを超える画像はアップロードできない(): void
     {
         $this->actingAs($this->admin, 'admin')
             ->post(route('admin.plans.store'), [
                 'name'   => 'テストプラン',
-                'images' => [UploadedFile::fake()->image('large.jpg')->size(2049)],
+                'images' => [UploadedFile::fake()->image('large.jpg')->size(15361)],
             ])
             ->assertSessionHasErrors('images.0');
     }


### PR DESCRIPTION
## Summary

- `PlanRequest` の `images.*` バリデーション `max:2048` → `max:15360` に変更
- テストのファイルサイズ境界値を 2049KB → 15361KB に更新

## Test plan

- [x] 15MB以下の画像がアップロードできること
- [x] 15MBを超える画像がバリデーションエラーになること
- [x] テストスイートがすべてパスすること

Closes #196
