### PR TITLE
ci: CI/CDパイプラインを整備する（lint・test・本番デプロイ統合）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,28 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: sail
           DB_PASSWORD: password
+
+  deploy:
+    needs: [lint-and-analyse, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev/hotel-reservation'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to production
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.PRODUCTION_USER }}
+          key: ${{ secrets.PRODUCTION_KEY }}
+          script: |
+            cd /var/www/hotel-reservation
+            git pull origin dev/hotel-reservation
+            cd hotel-reservation/src
+            composer install --optimize-autoloader
+            npm install
+            npm run build
+            php artisan migrate --force
+            php artisan config:cache
+            php artisan route:cache
+            php artisan view:cache
+            sudo systemctl reload php8.5-fpm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ User/ と Admin/ で似た処理が必要な場合は、コントローラーは
 | #178 | chore: DBインデックスを追加する（reservations・inquiries・accommodation_plans・reservation_slots） | chore/issue-178 |
 | #179 | refactor: CalendarAvailability::fromCount()を追加してマジックナンバーを除去する | refactor/issue-179 |
 | #162 | refactor: FormRequestクラスを導入してバリデーションをコントローラーから分離する | refactor/issue-162 |
+| #196 | fix: プラン画像アップロードの上限を 2MB → 15MB に緩和する | fix/issue-196 |
 
 ### 進行中・残タスク
 


### PR DESCRIPTION
## Summary

- `deploy.yml` を削除し `ci.yml` にデプロイジョブを統合
- デプロイは `lint-and-analyse` と `test` の両方が成功した場合のみ実行
- デプロイトリガーは `dev/hotel-reservation` への push のみ（PR時は走らない）

## CI/CDフロー

| イベント | lint・test | deploy |
|---------|-----------|--------|
| feat/* push | 走らない | 走らない |
| PR → dev | ✅ | ✅ しない |
| dev へのマージ | ✅ | ✅（CI通過後） |

## Test plan

- [ ] feat/* ブランチのpushでCIが走らないこと
- [ ] PRでlint・testが走ること
- [ ] dev/hotel-reservationへのマージでデプロイまで走ること

Closes #199