### PR TITLE
feat: プラン編集画面の画像管理を改善する（個別削除・追加アップロード）

### DIFF
--- a/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
+++ b/hotel-reservation/src/app/Http/Controllers/Admin/Plan/UpdateController.php
@@ -25,6 +25,7 @@ class UpdateController extends Controller
             $validated['description'] ?? null,
             $validated['images'] ?? [],
             $prices,
+            array_map('intval', $validated['delete_image_ids'] ?? []),
         );
 
         return redirect()->route('admin.plans.index');

--- a/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
+++ b/hotel-reservation/src/app/Http/Requests/Admin/Plan/PlanRequest.php
@@ -15,12 +15,14 @@ class PlanRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name'        => ['required', 'string', 'max:255'],
-            'description' => ['nullable', 'string'],
-            'images'      => ['nullable', 'array'],
-            'images.*'    => ['image', 'max:15360', 'mimes:jpg,jpeg,png,webp'],
-            'prices'      => ['nullable', 'array'],
-            'prices.*'    => ['nullable', 'integer', 'min:0'],
+            'name'               => ['required', 'string', 'max:255'],
+            'description'        => ['nullable', 'string'],
+            'images'             => ['nullable', 'array'],
+            'images.*'           => ['image', 'max:15360', 'mimes:jpg,jpeg,png,webp'],
+            'prices'             => ['nullable', 'array'],
+            'prices.*'           => ['nullable', 'integer', 'min:0'],
+            'delete_image_ids'   => ['nullable', 'array'],
+            'delete_image_ids.*' => ['integer', 'exists:plan_images,id'],
         ];
     }
 }

--- a/hotel-reservation/src/app/Services/AccommodationPlanService.php
+++ b/hotel-reservation/src/app/Services/AccommodationPlanService.php
@@ -28,21 +28,26 @@ class AccommodationPlanService
     /**
      * @param UploadedFile[] $images
      * @param array<int, int> $prices
+     * @param int[] $deleteImageIds
      */
     public function update(
         AccommodationPlan $plan,
         string $name,
         ?string $description,
         array $images,
-        array $prices
+        array $prices,
+        array $deleteImageIds = []
     ): void {
         $plan->update([
             'name'        => $name,
             'description' => $description,
         ]);
 
+        if (!empty($deleteImageIds)) {
+            $this->deleteImagesByIds($plan, $deleteImageIds);
+        }
+
         if (!empty($images)) {
-            $this->deleteImages($plan);
             $this->saveImages($plan, $images);
         }
 
@@ -73,6 +78,16 @@ class AccommodationPlanService
             Storage::disk('public')->delete($planImage->image_path);
         }
         $plan->planImages()->delete();
+    }
+
+    /** @param int[] $ids */
+    private function deleteImagesByIds(AccommodationPlan $plan, array $ids): void
+    {
+        $images = $plan->planImages()->whereIn('id', $ids)->get();
+        foreach ($images as $image) {
+            Storage::disk('public')->delete($image->image_path);
+        }
+        $plan->planImages()->whereIn('id', $ids)->delete();
     }
 
     /** @param array<int, int> $prices */

--- a/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
+++ b/hotel-reservation/src/resources/views/admin/plan/edit.blade.php
@@ -44,15 +44,28 @@
                 </div>
 
                 <div class="mb-3">
-                    <label class="form-label">画像（変更する場合のみ）</label>
-                    <input type="file" name="images[]" multiple accept="image/*" class="form-control">
+                    <label class="form-label">既存画像</label>
                     @if ($plan->planImages->isNotEmpty())
-                        <div class="d-flex gap-2 flex-wrap mt-2">
+                        <div class="d-flex gap-3 flex-wrap mb-2" id="existing-images">
                             @foreach ($plan->planImages as $image)
-                                <img src="{{ \Illuminate\Support\Facades\Storage::url($image->path) }}" alt="" style="height:60px; object-fit:cover; border-radius:4px;">
+                                <div class="position-relative" id="image-wrapper-{{ $image->id }}">
+                                    <img src="{{ \Illuminate\Support\Facades\Storage::url($image->image_path) }}"
+                                         alt="" style="height:120px; width:120px; object-fit:cover; border-radius:6px;">
+                                    <button type="button"
+                                            class="btn btn-sm btn-danger position-absolute top-0 end-0 p-0 lh-1"
+                                            style="width:22px; height:22px; font-size:14px;"
+                                            onclick="markDelete({{ $image->id }})"
+                                            title="削除">×</button>
+                                </div>
                             @endforeach
                         </div>
+                    @else
+                        <p class="text-muted small mb-2">画像はありません</p>
                     @endif
+
+                    <label class="form-label mt-2">画像を追加</label>
+                    <input type="file" name="images[]" multiple accept="image/*" class="form-control">
+                    <div class="form-text">JPG・PNG・WebP、各15MB以内</div>
                 </div>
 
                 <div class="mb-4">
@@ -74,8 +87,21 @@
                     </div>
                 </div>
 
+                <div id="delete-inputs"></div>
+
                 <button type="submit" class="btn btn-dark">更新</button>
             </form>
+
+            <script>
+                function markDelete(id) {
+                    document.getElementById('image-wrapper-' + id).remove();
+                    const input = document.createElement('input');
+                    input.type  = 'hidden';
+                    input.name  = 'delete_image_ids[]';
+                    input.value = id;
+                    document.getElementById('delete-inputs').appendChild(input);
+                }
+            </script>
         </div>
     </div>
 

--- a/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
@@ -207,7 +207,7 @@ class PlanControllerTest extends TestCase
         $plan = AccommodationPlan::factory()->create();
         $keep  = $plan->planImages()->create(['name' => 'keep.jpg',   'image_path' => 'plan-images/keep.jpg']);
         $target = $plan->planImages()->create(['name' => 'delete.jpg', 'image_path' => 'plan-images/delete.jpg']);
-        Storage::disk('public')->put('plan-images/keep.jpg',   'dummy');
+        Storage::disk('public')->put('plan-images/keep.jpg', 'dummy');
         Storage::disk('public')->put('plan-images/delete.jpg', 'dummy');
 
         $this->actingAs($this->admin, 'admin')
@@ -217,7 +217,7 @@ class PlanControllerTest extends TestCase
             ])
             ->assertRedirect(route('admin.plans.index'));
 
-        $this->assertDatabaseHas('plan_images',    ['id' => $keep->id]);
+        $this->assertDatabaseHas('plan_images', ['id' => $keep->id]);
         $this->assertDatabaseMissing('plan_images', ['id' => $target->id]);
         $this->assertTrue(Storage::disk('public')->exists('plan-images/keep.jpg'));
         $this->assertFalse(Storage::disk('public')->exists('plan-images/delete.jpg'));

--- a/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/Admin/Plan/PlanControllerTest.php
@@ -202,6 +202,44 @@ class PlanControllerTest extends TestCase
         ]);
     }
 
+    public function test_更新時に既存画像を指定して個別削除できる(): void
+    {
+        $plan = AccommodationPlan::factory()->create();
+        $keep  = $plan->planImages()->create(['name' => 'keep.jpg',   'image_path' => 'plan-images/keep.jpg']);
+        $target = $plan->planImages()->create(['name' => 'delete.jpg', 'image_path' => 'plan-images/delete.jpg']);
+        Storage::disk('public')->put('plan-images/keep.jpg',   'dummy');
+        Storage::disk('public')->put('plan-images/delete.jpg', 'dummy');
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.plans.update', $plan), [
+                'name'             => $plan->name,
+                'delete_image_ids' => [$target->id],
+            ])
+            ->assertRedirect(route('admin.plans.index'));
+
+        $this->assertDatabaseHas('plan_images',    ['id' => $keep->id]);
+        $this->assertDatabaseMissing('plan_images', ['id' => $target->id]);
+        $this->assertTrue(Storage::disk('public')->exists('plan-images/keep.jpg'));
+        $this->assertFalse(Storage::disk('public')->exists('plan-images/delete.jpg'));
+    }
+
+    public function test_更新時に既存画像を残しつつ新規画像を追加できる(): void
+    {
+        $plan     = AccommodationPlan::factory()->create();
+        $existing = $plan->planImages()->create(['name' => 'existing.jpg', 'image_path' => 'plan-images/existing.jpg']);
+
+        $this->actingAs($this->admin, 'admin')
+            ->put(route('admin.plans.update', $plan), [
+                'name'   => $plan->name,
+                'images' => [UploadedFile::fake()->image('new.jpg')],
+            ])
+            ->assertRedirect(route('admin.plans.index'));
+
+        $plan->refresh();
+        $this->assertDatabaseHas('plan_images', ['id' => $existing->id]);
+        $this->assertCount(2, $plan->planImages);
+    }
+
     // ----------------------------------------------------------------
     // DestroyController
     // ----------------------------------------------------------------

--- a/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
+++ b/hotel-reservation/src/tests/Feature/Services/AccommodationPlanServiceTest.php
@@ -85,13 +85,10 @@ class AccommodationPlanServiceTest extends TestCase
         ]);
     }
 
-    public function test_編集時に新しい画像を指定すると既存画像が置き換えられる(): void
+    public function test_編集時に新しい画像を指定すると既存画像に追加される(): void
     {
         $plan = AccommodationPlan::factory()->create();
-        $oldImage = UploadedFile::fake()->image('old.jpg');
-        $this->service->store($plan->name, null, [$oldImage], []);
-        // 既存画像を直接付与
-        $plan->planImages()->create([
+        $existing = $plan->planImages()->create([
             'name'       => 'old.jpg',
             'image_path' => 'plan-images/old.jpg',
         ]);
@@ -99,9 +96,28 @@ class AccommodationPlanServiceTest extends TestCase
         $newImage = UploadedFile::fake()->image('new.jpg');
         $this->service->update($plan, $plan->name, null, [$newImage], []);
 
-        $freshImage = $plan->fresh()->planImages->first();
+        $fresh = $plan->fresh()->planImages;
+        $this->assertCount(2, $fresh);
+        $this->assertTrue($fresh->contains('id', $existing->id));
+    }
+
+    public function test_編集時にdelete_image_idsを指定すると対象画像が削除される(): void
+    {
+        Storage::fake('public');
+        $plan   = AccommodationPlan::factory()->create();
+        $target = $plan->planImages()->create([
+            'name'       => 'delete.jpg',
+            'image_path' => 'plan-images/delete.jpg',
+        ]);
+        $keep = $plan->planImages()->create([
+            'name'       => 'keep.jpg',
+            'image_path' => 'plan-images/keep.jpg',
+        ]);
+
+        $this->service->update($plan, $plan->name, null, [], [], [$target->id]);
+
         $this->assertCount(1, $plan->fresh()->planImages);
-        $this->assertSame(basename($freshImage->image_path), $freshImage->name);
+        $this->assertTrue($plan->fresh()->planImages->contains('id', $keep->id));
     }
 
     public function test_編集時に画像を指定しない場合は既存画像が保持される(): void


### PR DESCRIPTION
closes #198

## 変更内容

### ビジネスロジック（Service）
- `AccommodationPlanService::update()` を修正：新規画像アップロード時に既存画像を全削除する挙動を廃止
- `deleteImageIds` 引数を追加し、指定されたIDの画像だけを個別削除する `deleteImagesByIds()` を実装

### バリデーション（Request）
- `PlanRequest` に `delete_image_ids` / `delete_image_ids.*` ルールを追加（`exists:plan_images,id` で他プランの画像を削除できないよう保護）

### UI（View）
- 既存画像を120px サムネイルで一覧表示
- 各画像に × ボタンを設置、クリックで `delete_image_ids[]` hidden input を生成して画像を非表示にするJSを追加
- ファイルアップロードは「画像を追加」として既存画像とは独立
- `$image->path` → `$image->image_path` の列名バグを修正

### テスト
- `PlanControllerTest` に2件追加（個別削除・追加アップロード）
- `AccommodationPlanServiceTest` の「置き換えられる」テストを新挙動（追加）に更新、`delete_image_ids` テストを新規追加

## Test plan

- [ ] 既存画像が120pxサムネイルで表示される
- [ ] × ボタンで画像が即時非表示になり、保存後DBから削除される
- [ ] 新規画像を追加しても既存画像が消えない
- [ ] CI 全178テスト通過