### PR TITLE
feat: 宿泊者プラン一覧のページネーションを整備する

### DIFF
--- a/hotel-reservation/src/database/seeders/AccommodationPlanSeeder.php
+++ b/hotel-reservation/src/database/seeders/AccommodationPlanSeeder.php
@@ -84,5 +84,42 @@ class AccommodationPlanSeeder extends Seeder
                 }
             }
         }
+
+        // ページネーション確認用（3ページ分になるよう追加、合計25件）
+        $extraPlans = [
+            ['name' => '【早割30】30日前予約限定プラン',              'prices' => [[$standard, 10000], [$deluxe, 15000], [$suite, 28000]]],
+            ['name' => '【連泊割】3泊以上でお得プラン',               'prices' => [[$standard, 11000], [$deluxe, 16000], [$suite, 30000]]],
+            ['name' => '【ファミリー】子連れ大歓迎プラン',            'prices' => [[$standard, 20000], [$deluxe, 28000]]],
+            ['name' => '【シニア】ゆったり温泉湯治プラン',            'prices' => [[$standard, 15000], [$deluxe, 22000]]],
+            ['name' => '【カップル】二人旅ロマンティックプラン',      'prices' => [[$deluxe, 36000], [$suite, 65000]]],
+            ['name' => '【ビジネス】出張応援シンプルプラン',          'prices' => [[$standard, 9000]]],
+            ['name' => '【女子旅】エステ＆スパ付きプラン',            'prices' => [[$deluxe, 38000], [$suite, 70000]]],
+            ['name' => '【冬季限定】雪見鍋と温泉プラン',              'prices' => [[$standard, 18000], [$deluxe, 26000], [$suite, 48000]]],
+            ['name' => '【春限定】花見と懐石料理プラン',              'prices' => [[$standard, 16000], [$deluxe, 24000], [$suite, 45000]]],
+            ['name' => '【夏限定】川遊びと流しそうめんプラン',        'prices' => [[$standard, 14000], [$deluxe, 20000]]],
+            ['name' => '【秋限定】紅葉狩りと山の幸プラン',            'prices' => [[$standard, 17000], [$deluxe, 25000], [$suite, 46000]]],
+            ['name' => '【ペット同伴】愛犬と一緒に泊まれるプラン',   'prices' => [[$standard, 13000], [$deluxe, 19000]]],
+            ['name' => '【禁煙】空気清浄ルームプラン',                'prices' => [[$standard, 12000], [$deluxe, 18000], [$suite, 35000]]],
+            ['name' => '【長期滞在】1週間まるごとステイプラン',       'prices' => [[$standard, 60000], [$deluxe, 90000]]],
+            ['name' => '【ワーケーション】高速Wi-Fi完備・仕事も捗るプラン', 'prices' => [[$standard, 10500], [$deluxe, 16500]]],
+            ['name' => '【VIP】プライベートダイニング付き最上級プラン', 'prices' => [[$suite, 120000]]],
+            ['name' => '【学生・若者割】25歳以下限定お得プラン',      'prices' => [[$standard, 7500], [$deluxe, 12000]]],
+            ['name' => '【温泉三昧】貸切風呂2時間付きプラン',         'prices' => [[$standard, 19000], [$deluxe, 27000], [$suite, 50000]]],
+            ['name' => '【ヨガ＆瞑想】朝の自然体験プラン',            'prices' => [[$standard, 21000], [$deluxe, 32000]]],
+            ['name' => '【釣り体験】川釣りと地魚料理プラン',          'prices' => [[$standard, 23000], [$deluxe, 33000], [$suite, 58000]]],
+        ];
+
+        foreach ($extraPlans as $data) {
+            $plan = AccommodationPlan::create(['name' => $data['name']]);
+            foreach ($data['prices'] as [$roomType, $price]) {
+                if ($roomType) {
+                    PlanRoomPrice::create([
+                        'accommodation_plan_id' => $plan->id,
+                        'room_type_id'          => $roomType->id,
+                        'price'                 => $price,
+                    ]);
+                }
+            }
+        }
     }
 }

--- a/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
+++ b/hotel-reservation/src/tests/Feature/User/Plan/PlanControllerTest.php
@@ -58,6 +58,28 @@ class PlanControllerTest extends TestCase
             ->assertSee('12,000');
     }
 
+    public function test_1ページに12件までしか表示されない(): void
+    {
+        AccommodationPlan::factory()->count(13)->create();
+
+        $this->get(route('user.plans.index'))
+            ->assertOk()
+            ->assertViewHas('plans', fn ($plans) => $plans->count() === 12);
+    }
+
+    public function test_2ページ目には残りのプランが表示される(): void
+    {
+        AccommodationPlan::factory()->count(13)->sequence(
+            fn ($s) => ['name' => "プラン{$s->index}"]
+        )->create();
+
+        $last = AccommodationPlan::latest('id')->first();
+
+        $this->get(route('user.plans.index') . '?page=2')
+            ->assertOk()
+            ->assertSee($last->name);
+    }
+
     public function test_削除済みのプランは一覧に表示されない(): void
     {
         $plan = AccommodationPlan::factory()->create(['name' => '削除済みプラン']);


### PR DESCRIPTION
closes #202

## 変更内容

- `PlanControllerTest` にページネーションのテストを2件追加
  - 1ページに12件までしか表示されない
  - 2ページ目には残りのプランが表示される
- `AccommodationPlanSeeder` にプランを20件追加（合計25件・3ページ分で動作確認可能）

## 補足

`Paginator::useBootstrapFive()` は #208 でマージ済みのため、このPRには含まない。

## Test plan

- [x] 宿泊者プラン一覧で Bootstrap 5 スタイルのページネーションが1つ表示される
- [x] 2ページ目・3ページ目が正しく機能する
- [x] CI 全180テスト通過