### PR TITLE
ci: デプロイジョブのタイムアウト耐性を強化する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,13 @@ jobs:
           host: ${{ secrets.PRODUCTION_HOST }}
           username: ${{ secrets.PRODUCTION_USER }}
           key: ${{ secrets.PRODUCTION_KEY }}
+          command_timeout: 20m
           script: |
+            set -e
             cd /var/www/hotel-reservation
             git pull origin dev/hotel-reservation
             cd hotel-reservation/src
-            composer install --optimize-autoloader
+            COMPOSER_PROCESS_TIMEOUT=600 composer install --optimize-autoloader
             npm install
             npm run build
             php artisan migrate --force


### PR DESCRIPTION
## Summary

- `COMPOSER_PROCESS_TIMEOUT=600` を設定し、t3.micro の負荷スパイク時に `php artisan package:discover` が Composer の内部 300 秒タイムアウトを超えてしまう問題を緩和
- `command_timeout: 20m` で SSH アクション全体の上限を 10 分 → 20 分に引き上げ
- `set -e` を追加し、途中コマンドが失敗しても後続コマンドが走り続けるバグを修正

## 背景

PR #210 のマージ（CLAUDE.md のみ変更）でデプロイが失敗。`package:discover` が ~470 秒かかって Composer の 300 秒タイムアウトに引っかかり、SSH アクションの 10 分タイムアウトも超過した。再実行で成功したため一時的なリソース不足が原因。再発防止として余裕を持ったタイムアウト設定に変更する。

## Test plan

- [ ] CI の lint-and-analyse / test が通ること
- [ ] dev/hotel-reservation へのマージ後、deploy ジョブが成功すること