### PR TITLE
ci: デプロイ前に bootstrap/cache・storage のパーミッション修正を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
             cd /var/www/hotel-reservation
             git pull origin dev/hotel-reservation
             cd hotel-reservation/src
+            chmod -R 775 bootstrap/cache storage
             COMPOSER_PROCESS_TIMEOUT=600 composer install --optimize-autoloader
             npm install
             npm run build


### PR DESCRIPTION
## Summary

- `chmod -R 775 bootstrap/cache storage` を `composer install` の前に追加
- www-data（PHP-FPM）が書き込んだキャッシュファイルをデプロイユーザー（ubuntu）が上書きできず `package:discover` が失敗する問題を修正

## 背景

PR #212 で `set -e` を追加したことで、以前はタイムアウトまで気づかなかった根本原因が露わになった。`bootstrap/cache` のパーミッションが `www-data` 所有になっているとデプロイ時に書き込み不可となる。

## Test plan

- [ ] CI の lint-and-analyse / test が通ること
- [ ] dev/hotel-reservation マージ後に deploy ジョブが成功すること