### PR TITLE
ci: chmod を sudo chmod に変更する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             cd /var/www/hotel-reservation
             git pull origin dev/hotel-reservation
             cd hotel-reservation/src
-            chmod -R 775 bootstrap/cache storage
+            sudo chmod -R 775 bootstrap/cache storage
             COMPOSER_PROCESS_TIMEOUT=600 composer install --optimize-autoloader
             npm install
             npm run build


### PR DESCRIPTION
## Summary

- `chmod -R 775` → `sudo chmod -R 775` に変更
- storage/ 配下のファイルは www-data（PHP-FPM）が作成するため ubuntu ユーザーが直接 chmod できない

## 背景

PR #213 のデプロイで `chmod: cannot access 'storage/app/public/.gitignore': Permission denied` が発生。sudo systemctl はすでに動作しているので sudo chmod も通る想定。