### PR TITLE
ci: chown でデプロイユーザー所有に変更してから chmod する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
             cd /var/www/hotel-reservation
             git pull origin dev/hotel-reservation
             cd hotel-reservation/src
+            sudo chown -R "$(whoami)":www-data bootstrap/cache storage
             sudo chmod -R 775 bootstrap/cache storage
             COMPOSER_PROCESS_TIMEOUT=600 composer install --optimize-autoloader
             npm install


### PR DESCRIPTION
## Summary

- `sudo chmod -R 775` の前に `sudo chown -R $(whoami):www-data` を追加
- bootstrap/cache・storage が `www-data:www-data` 所有の場合、ubuntu は `other` 扱いになり 775 でも書き込めない
- chown でオーナーを ubuntu に変更することで composer の `package:discover` が書き込めるようにする

## 背景

PR #213・#214 で段階的に修正してきたが、根本原因は `chmod` だけでは不十分だった。www-data 所有ディレクトリに ubuntu が書けるためには chown が必要。